### PR TITLE
Add support for `load-pass-plugin` option

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -528,6 +528,11 @@ extension Driver {
     if !hasToolchainStdlib {
       try addPluginPathArguments(commandLine: &commandLine)
     }
+
+    if let passPluginPath = parsedOptions.getLastArgument(.loadPassPluginEQ),
+        isFrontendArgSupported(.loadPassPluginEQ) {
+      commandLine.appendFlag("-load-pass-plugin=\(passPluginPath.asSingle)")
+    }
   }
 
   mutating func addBridgingHeaderPCHCacheKeyArguments(commandLine: inout [Job.ArgTemplate],

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -8275,6 +8275,21 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(jobs[0].commandLine.contains(subsequence: featureArgs.map { Job.ArgTemplate.flag($0) }))
     }
   }
+
+  func testFrontendLoadPassPlugin() throws {
+#if os(Windows)
+    throw XCTSkip("'-load-pass-plugin' is not available on Windows.")
+#else
+    var driver = try Driver(args: ["swiftc", "foo.swift", "-load-pass-plugin=/path/to/plugin"])
+    guard driver.isFrontendArgSupported(.loadPassPluginEQ) else {
+      throw XCTSkip("Skipping: compiler does not support '-load-pass-plugin'.")
+    }
+    let plannedJobs = try driver.planBuild()
+    XCTAssertEqual(plannedJobs[0].kind, .compile)
+    XCTAssertTrue(plannedJobs[0].tool.name.hasSuffix("swift-frontend"))
+    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-load-pass-plugin=/path/to/plugin")))
+#endif
+  }
 }
 
 func assertString(


### PR DESCRIPTION
`Options.swift` has been regenerated so as to include `load-pass-plugin` option as well.

Frontend implementation at https://github.com/apple/swift/pull/68985.