### PR TITLE
SwiftDriver: initial work to properly handle android cross-compilation

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -182,26 +182,6 @@ extension Driver {
     try commandLine.appendAll(.F, .Fsystem, from: &parsedOptions)
     try commandLine.appendAll(.vfsoverlay, from: &parsedOptions)
 
-    if targetTriple.environment == .android {
-        if let ndk = env["ANDROID_NDK_ROOT"] {
-            var sysroot: AbsolutePath =
-                try AbsolutePath(validating: ndk)
-                    .appending(components: "toolchains", "llvm", "prebuilt")
-#if arch(x86_64)
-#if os(Windows)
-                    .appending(component: "windows-x86_64")
-#elseif os(Linux)
-                    .appending(component: "linux-x86_64")
-#else
-                    .appending(component: "darwin-x86_64")
-#endif
-#endif
-                    .appending(component: "sysroot")
-            commandLine.appendFlag("-sysroot")
-            commandLine.appendFlag(sysroot.pathString)
-        }
-    }
-
     if let gccToolchain = parsedOptions.getLastArgument(.gccToolchain) {
         appendXccFlag("--gcc-toolchain=\(gccToolchain.asSingle)")
     }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -182,6 +182,26 @@ extension Driver {
     try commandLine.appendAll(.F, .Fsystem, from: &parsedOptions)
     try commandLine.appendAll(.vfsoverlay, from: &parsedOptions)
 
+    if targetTriple.environment == .android {
+        if let ndk = env["ANDROID_NDK_ROOT"] {
+            var sysroot: AbsolutePath =
+                try AbsolutePath(validating: ndk)
+                    .appending(components: "toolchains", "llvm", "prebuilt")
+#if arch(x86_64)
+#if os(Windows)
+                    .appending(component: "windows-x86_64")
+#elseif os(Linux)
+                    .appending(component: "linux-x86_64")
+#else
+                    .appending(component: "darwin-x86_64")
+#endif
+#endif
+                    .appending(component: "sysroot")
+            commandLine.appendFlag("-sysroot")
+            commandLine.appendFlag(sysroot.pathString)
+        }
+    }
+
     if let gccToolchain = parsedOptions.getLastArgument(.gccToolchain) {
         appendXccFlag("--gcc-toolchain=\(gccToolchain.asSingle)")
     }

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -117,4 +117,50 @@ public final class GenericUnixToolchain: Toolchain {
     let environment = (targetTriple.environment == .android) ? "-android" : ""
     return "libclang_rt.\(sanitizer.libraryName)-\(targetTriple.archName)\(environment).a"
   }
+
+  private func getAndroidNDKHostOSSuffix() -> String? {
+#if os(Windows)
+    "windows"
+#elseif os(Linux)
+    "linux"
+#elseif os(macOS)
+    "darwin"
+#else
+    // The NDK is only available on macOS, linux and windows hosts.
+    nil
+#endif
+  }
+
+  func getAndroidNDKSysrootPath() throws -> AbsolutePath? {
+#if arch(x86_64)
+    // The NDK's sysroot should be specified in the environment.
+    guard let ndk = env["ANDROID_NDK_ROOT"],
+          let osSuffix = getAndroidNDKHostOSSuffix() else {
+      return  nil
+    }
+    var sysroot: AbsolutePath =
+        try AbsolutePath(validating: ndk)
+            .appending(components: "toolchains", "llvm", "prebuilt")
+            .appending(component: "\(osSuffix)-x86_64")
+            .appending(component: "sysroot")
+    return sysroot
+#else
+    // The NDK is only available on an x86_64 host.
+    return nil
+#endif
+  }
+
+  public func addPlatformSpecificCommonFrontendOptions(
+    commandLine: inout [Job.ArgTemplate],
+    inputs: inout [TypedVirtualPath],
+    frontendTargetInfo: FrontendTargetInfo,
+    driver: inout Driver
+  ) throws {
+    if driver.targetTriple.environment == .android {
+      if let sysroot = try getAndroidNDKSysrootPath() {
+        commandLine.appendFlag("-sysroot")
+        commandLine.appendFlag(sysroot.pathString)
+      }
+    }
+  }
 }

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -788,6 +788,7 @@ extension Option {
   public static let swiftVersion: Option = Option("-swift-version", .separate, attributes: [.frontend, .moduleInterface], metaVar: "<vers>", helpText: "Interpret input according to a specific Swift language version number")
   public static let switchCheckingInvocationThresholdEQ: Option = Option("-switch-checking-invocation-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver])
   public static let symbolGraphMinimumAccessLevel: Option = Option("-symbol-graph-minimum-access-level", .separate, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], metaVar: "<level>", helpText: "Include symbols with this access level or more when emitting a symbol graph")
+  public static let sysroot: Option = Option("-sysroot", .separate, attributes: [.frontend, .argumentIsPath], metaVar: "<sysroot>", helpText: "Native Platform sysroot")
   public static let S: Option = Option("-S", .flag, alias: Option.emitAssembly, attributes: [.frontend, .noInteractive], group: .modes)
   public static let tabWidth: Option = Option("-tab-width", .separate, attributes: [.noInteractive, .noBatch, .indent], metaVar: "<n>", helpText: "Width of tab character.", group: .codeFormatting)
   public static let targetCpu: Option = Option("-target-cpu", .separate, attributes: [.frontend, .moduleInterface], helpText: "Generate code for a particular CPU variant")
@@ -1651,6 +1652,7 @@ extension Option {
       Option.swiftVersion,
       Option.switchCheckingInvocationThresholdEQ,
       Option.symbolGraphMinimumAccessLevel,
+      Option.sysroot,
       Option.S,
       Option.tabWidth,
       Option.targetCpu,


### PR DESCRIPTION
The intent here is to permit the Windows/macOS style cross-compilation for Android. This involves passing `-sdk` with the path to the "Swift SDK" which overlays the system's native SDK (NDK). The `ANDROID_NDK_ROOT` is a well-defined environment variable (setup by the SDK installer as well as a general expectation for Android development) that identifies the root of the installation of the NDK. This allows us to locate the native SDK root (`--sysroot`) for driving the linker driver amongst other paths.