### PR TITLE
[6.0🍒] Resolve main executable symlink when looking up driver-adjacent subcommand binaries

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -28,11 +28,13 @@ import Dispatch
 import WinSDK
 #endif
 
-import enum TSCBasic.ProcessEnv
+import struct TSCBasic.AbsolutePath
 import func TSCBasic.exec
+import enum TSCBasic.ProcessEnv
 import class TSCBasic.DiagnosticsEngine
 import class TSCBasic.Process
 import class TSCBasic.ProcessSet
+import func TSCBasic.resolveSymlinks
 import protocol TSCBasic.DiagnosticData
 import var TSCBasic.localFileSystem
 
@@ -84,12 +86,17 @@ do {
   }
 
   let (mode, arguments) = try Driver.invocationRunMode(forArgs: CommandLine.arguments)
-
   if case .subcommand(let subcommand) = mode {
     // We are running as a subcommand, try to find the subcommand adjacent to the executable we are running as.
     // If we didn't find the tool there, let the OS search for it.
-    let subcommandPath = Process.findExecutable(CommandLine.arguments[0])?.parentDirectory.appending(component: subcommand)
-                         ?? Process.findExecutable(subcommand)
+    let subcommandPath: AbsolutePath?
+    if let executablePath = Process.findExecutable(CommandLine.arguments[0]) {
+      // Attempt to resolve the executable symlink in order to be able to
+      // resolve compiler-adjacent library locations.
+      subcommandPath = try TSCBasic.resolveSymlinks(executablePath).parentDirectory.appending(component: subcommand)
+    } else {
+      subcommandPath = Process.findExecutable(subcommand)
+    }
 
     guard let subcommandPath = subcommandPath,
           localFileSystem.exists(subcommandPath) else {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-driver/pull/1583
-------------------------------------------------------
**Explanation**: As per https://github.com/apple/swift/issues/70932, when swift-driver is installed via a symlink, it is not able to correctly resolve adjacent tool binaries by following their corresponding symlinks. This is a regression from the old, legacy C++ driver. This change fixes this behavior by having the driver resolve its own path if it is a symlink, first. 

**Risk**: Low. Cases where the added code takes effect were previously not working. 

**Testing**: Expected behavior validated manually by implementor and issue originator (on `main`)

Resolves https://github.com/apple/swift/issues/70932