### PR TITLE
🍒[Swift 6.0] Allow overriding clang++ with an environment variable

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -196,7 +196,10 @@ extension Toolchain {
 
   /// - Returns: String in the form of: `SWIFT_DRIVER_TOOLNAME_EXEC`
   private func envVarName(for toolName: String) -> String {
-    let lookupName = toolName.replacingOccurrences(of: "-", with: "_").uppercased()
+    let lookupName = toolName
+        .replacingOccurrences(of: "-", with: "_")
+        .replacingOccurrences(of: "+", with: "X")
+        .uppercased()
     return "SWIFT_DRIVER_\(lookupName)_EXEC"
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6806,6 +6806,41 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(jobs.first!.tool.name, swiftHelp.pathString)
   }
 
+  func testSwiftClangOverride() throws {
+    var env = ProcessEnv.vars
+    let swiftClang = try AbsolutePath(validating: "/A/Path/swift-clang")
+    env["SWIFT_DRIVER_CLANG_EXEC"] = swiftClang.pathString
+
+    var driver = try Driver(
+      args: ["swiftc", "-emit-library", "foo.swift", "bar.o", "-o", "foo.l"],
+      env: env)
+    let jobs = try driver.planBuild()
+    XCTAssertEqual(jobs.count, 2)
+    let linkJob = jobs[1]
+    XCTAssertEqual(linkJob.tool.name, swiftClang.pathString)
+  }
+
+  func testSwiftClangxxOverride() throws {
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+      throw XCTSkip("Darwin always uses `clang` to link")
+#else
+    var env = ProcessEnv.vars
+    let swiftClang = try AbsolutePath(validating: "/A/Path/swift-clang")
+    let swiftClangxx = try AbsolutePath(validating: "/A/Path/swift-clang++")
+    env["SWIFT_DRIVER_CLANG_EXEC"] = swiftClang.pathString
+    env["SWIFT_DRIVER_CLANGXX_EXEC"] = swiftClangxx.pathString
+
+    var driver = try Driver(
+      args: ["swiftc", "-cxx-interoperability-mode=swift-5.9", "-emit-library",
+             "foo.swift", "bar.o", "-o", "foo.l"],
+      env: env)
+
+    let jobs = try driver.planBuild()
+    let linkJob = jobs.last!
+    XCTAssertEqual(linkJob.tool.name, swiftClangxx.pathString)
+#endif
+  }
+
   func testSourceInfoFileEmitOption() throws {
     // implicit
     do {


### PR DESCRIPTION
Cherry-picking: https://github.com/apple/swift-driver/pull/1605

> '+' isn't allowed in environment variable names so it's impossible to set the Clang++ executable at the moment. Replace + with X so that we can set `SWIFT_DRIVER_CLANGXX_EXEC` to set the clang++ executable.
> 
> Fixes: rdar://128007218

Explanation: Replaces `+` with `X` in the toolchain while doing tool lookup from an environment variable because `+` is not allowed in valid environment variable names. This prevents us from telling the driver where to look for the clang++ binary.

Risk: Low. Only affects projects that set the `SWIFT_DRIVER_CLANGXX_EXEC` environment variable. Since that doesn't do anything today, that would be a silly thing to do. Otherwise, projects cannot currently set `SWIFT_DRIVER_CLANG++_EXEC` because that's an invalid environment variable name.

Testing: Added test to verify that the substitution is made correctly.

Fixes: rdar://128007218