### PR TITLE
[6.0] Add In-process plugin server path

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -781,10 +781,19 @@ extension Driver {
     guard isFrontendArgSupported(.pluginPath) else {
       return
     }
+    let pluginPathRoot = VirtualPath.absolute(try toolchain.executableDir.parentDirectory)
+
+    if isFrontendArgSupported(.inProcessPluginServerPath) {
+      commandLine.appendFlag(.inProcessPluginServerPath)
+#if os(Windows)
+      commandLine.appendPath(pluginPathRoot.appending(components: "bin", sharedLibraryName("SwiftInProcPluginServer")))
+#else
+      commandLine.appendPath(pluginPathRoot.appending(components: "lib", "swift", "host", sharedLibraryName("libSwiftInProcPluginServer")))
+#endif
+    }
 
     // Default paths for compiler plugins found within the toolchain
     // (loaded as shared libraries).
-    let pluginPathRoot = VirtualPath.absolute(try toolchain.executableDir.parentDirectory)
     commandLine.appendFlag(.pluginPath)
     commandLine.appendPath(pluginPathRoot.pluginPath)
 

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -543,6 +543,7 @@ extension Option {
   public static let importPrescan: Option = Option("-import-prescan", .flag, attributes: [.frontend, .noDriver], helpText: "When performing a dependency scan, only identify all imports of the main Swift module sources")
   public static let importUnderlyingModule: Option = Option("-import-underlying-module", .flag, attributes: [.frontend, .noInteractive], helpText: "Implicitly imports the Objective-C half of a module")
   public static let inPlace: Option = Option("-in-place", .flag, attributes: [.noInteractive, .noBatch, .indent], helpText: "Overwrite input file with formatted file.", group: .codeFormatting)
+  public static let inProcessPluginServerPath: Option = Option("-in-process-plugin-server-path", .separate, attributes: [.frontend, .argumentIsPath], helpText: "Path to dynamic library plugin server")
   public static let includeSpiSymbols: Option = Option("-include-spi-symbols", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Add symbols with SPI information to the symbol graph")
   public static let incremental: Option = Option("-incremental", .flag, attributes: [.helpHidden, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Perform an incremental build if possible")
   public static let indentSwitchCase: Option = Option("-indent-switch-case", .flag, attributes: [.noInteractive, .noBatch, .indent], helpText: "Indent cases in switch statements.", group: .codeFormatting)
@@ -1393,6 +1394,7 @@ extension Option {
       Option.importPrescan,
       Option.importUnderlyingModule,
       Option.inPlace,
+      Option.inProcessPluginServerPath,
       Option.includeSpiSymbols,
       Option.incremental,
       Option.indentSwitchCase,


### PR DESCRIPTION
Cherry-pick #1616 into `release/6.0`

(copied from https://github.com/swiftlang/swift/pull/74740)
* **Explanation**: swift-syntax libraries in compiler has been complied with `-enable-library-evolution` because the toolchain provides them as a public interface for building plugins (i.e. `lib/swift/host/*.swiftmodule`). But that was not great for the performance in the compiler. This PR changes that by separating swift-syntax libs for the compiler from the one for the plugins. So the compiler and the plugin now can use different version/ABI of swift-syntax libraries from the compiler. Now swift-syntax for the compiler are compiled without library evolution.
* **Scope**: Macro plugins
* **Risk**: Mid. This changes the mechanism of in-process plugins significantly. Now in-process plugins are communicate with the compiler using the same messaging serialization with other plugins (i.e. `swift-plugin-server`, and other executable plugins), instead of directly calling the `Macro.Type` expansion method. Also, to separate the swift-syntax libraries, this introduces another set of shared swift-syntax libraries in the toolchain.
* **Testing**: Passes current test suite.
* **Issue**: rdar://130532628
* **Reviewer**: Hamish Knight (@hamishknight) Alex Hoppen (@ahoppen) Ben Barham (@bnbarham)