### PR TITLE
Import new Android overlay or Bionic module

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -19,6 +19,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif
@@ -136,7 +138,11 @@ import var TSCBasic.stdoutStream
         }
 #else
       case .signalled(let signal):
+#if canImport(Bionic)
+        let errorMessage = String(cString: strsignal(signal))
+#else
         let errorMessage = strsignal(signal).map { String(cString: $0) } ?? ""
+#endif
         messages = constructJobSignalledMessages(job: job, error: errorMessage, output: output,
                                                  signal: signal, pid: pid).map {
           ParsableMessage(name: job.kind.rawValue, kind: .signalled($0))

--- a/Sources/SwiftDriver/SwiftScan/Loader.swift
+++ b/Sources/SwiftDriver/SwiftScan/Loader.swift
@@ -21,6 +21,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 internal enum Loader {

--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -18,6 +18,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 /// Represents a time point value with nanosecond precision.

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -16,6 +16,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 func argumentNeedsQuoting(_ argument: String) -> Bool {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -19,6 +19,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 import class TSCBasic.DiagnosticsEngine

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -20,6 +20,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 import Dispatch


### PR DESCRIPTION
Also, fix build error because [`strsignal()` always returns `_Nonnull` in the latest Android NDK 26](https://android.googlesource.com/platform/bionic/+/02c4ef4d78d77da7b7974c46cfa20a8f9aaa56d4/libc/include/string.h#134).

This new overlay was recently added in swiftlang/swift#72161 and swiftlang/swift#72634. I've been building it with this patch on my daily Android CI since then, finagolfin/swift-android-sdk#151, and natively on Android too.

@artemcm, should be an easy review.