### PR TITLE
[Explicit Module Builds] Emit scanner-global diagnostics on a total dependency scan failure

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -73,7 +73,7 @@ public struct Driver {
     case missingPCMArguments(String)
     case missingModuleDependency(String)
     case missingContextHashOnSwiftDependency(String)
-    case dependencyScanningFailure(Int, String)
+    case dependencyScanErrors
     case missingExternalDependency(String)
 
     public var description: String {
@@ -130,8 +130,8 @@ public struct Driver {
         return "Missing Module Dependency Info: \(moduleName)"
       case .missingContextHashOnSwiftDependency(let moduleName):
         return "Missing Context Hash for Swift dependency: \(moduleName)"
-      case .dependencyScanningFailure(let code, let error):
-        return "Module Dependency Scanner returned with non-zero exit status: \(code), \(error)"
+      case .dependencyScanErrors:
+        return "Dependency scan produced errors"
       case .unableToLoadOutputFileMap(let path, let error):
         return "unable to load output file map '\(path)': \(error)"
       case .missingExternalDependency(let moduleName):

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -230,8 +230,17 @@ public extension Driver {
                                                              diagnostics: &scanDiagnostics)
         try emitScannerDiagnostics(scanDiagnostics)
       } catch let DependencyScanningError.dependencyScanFailed(reason) {
+        // On a complete query failure, attempt to produce global scanner diagnostic state
         try emitGlobalScannerDiagnostics()
         throw DependencyScanningError.dependencyScanFailed(reason)
+      } catch let error {
+        // Otherwise, attempt to get at the query-specific diagnostic state
+        if scanDiagnostics.contains(where: {$0.severity == .error}) {
+          try emitScannerDiagnostics(scanDiagnostics)
+          throw Error.dependencyScanErrors
+        } else {
+          throw error
+        }
       }
     } else {
       // Fallback to legacy invocation of the dependency scanner with
@@ -306,8 +315,17 @@ public extension Driver {
                                                                           diagnostics: &scanDiagnostics)
         try emitScannerDiagnostics(scanDiagnostics)
       } catch let DependencyScanningError.dependencyScanFailed(reason) {
+        // On a complete query failure, attempt to produce global scanner diagnostic state
         try emitGlobalScannerDiagnostics()
         throw DependencyScanningError.dependencyScanFailed(reason)
+      } catch let error {
+        // Otherwise, attempt to get at the query-specific diagnostic state
+        if scanDiagnostics.contains(where: {$0.severity == .error}) {
+          try emitScannerDiagnostics(scanDiagnostics)
+          throw Error.dependencyScanErrors
+        } else {
+          throw error
+        }
       }
     } else {
       // Fallback to legacy invocation of the dependency scanner with


### PR DESCRIPTION
The driver queries per-scan diagnostics when the scanner query produces a result that is incomplete or invalid. When the scanner query completely fails to produce any kind of output, it may still be useful to fallback onto the global scanner diagnostic state.

The more forward-looking solution is to ensure scanner queries *always* produce enough state to be able to diagnose their failure. This PR also lays foundation for that with an attempt to query scanner-produced diagnostics when a query returned incomplete or invalid results. 

Resolves rdar://130897498