### PR TITLE
Ignore prebuilt module cache when building the prebuilt module cache

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -157,6 +157,18 @@ do {
         try localFileSystem.createDirectory(mcpPath, recursive: true)
       }
     }
+
+    // When building modules for an SDK,  ignore any existing prebuilt modules.
+    // modules. Do so by passing an intentially-bad path for the prebuilt
+    // module cache path that's derived from the output path (but not the same
+    // as that path). This prohibits the frontend scanning job from adding the
+    // default prebuilt module cache path, while ensuring that we find no
+    // prebuilt modules during this scan.
+    args.append("-Xfrontend")
+    args.append("-prebuilt-module-cache-path")
+    args.append("-Xfrontend")
+    args.append(outputDir.appending(component: "__nonexistent__").pathString)
+
     let baselineABIDir = try getArgumentAsPath("-baseline-abi-dir")
     var driver = try Driver(args: args,
                             diagnosticsOutput: .engine(diagnosticsEngine),


### PR DESCRIPTION
Explanation: When building modules for an SDK, we need to ignore any existing prebuilt modules to avoid building a partial prebuilt module cache. Make sure we do ignore them by passing down an intentionally-bogus path for the existing prebuilt module cache.
Scope: Prebuilt module cache generation logic only, very narrow.
Risk: Very low due to narrow scope.
Testing: Passes current test suite.
Main PR: https://github.com/swiftlang/swift-driver/pull/1649
Issue: rdar://131183526
