### PR TITLE
[6.0 🍒][PrebuiltModuleGen] Ensure the dependency scanner always ignores existing prebuilt modules

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -169,6 +169,19 @@ do {
     args.append("-Xfrontend")
     args.append(outputDir.appending(component: "__nonexistent__").pathString)
 
+    // If the compiler/scanner supports it, instruct it to ignore any existing prebuilt
+    // modules for which a textual interface is discovered, ensuring that modules
+    // always build from interface when one is available.
+    if let supportedFlagsTestDriver = try? Driver(args: ["swiftc", "-v"],
+                                                  executor: executor,
+                                                  compilerExecutableDir: swiftcPath.parentDirectory),
+       supportedFlagsTestDriver.isFrontendArgSupported(.moduleLoadMode) {
+      args.append("-Xfrontend")
+      args.append("-module-load-mode")
+      args.append("-Xfrontend")
+      args.append("only-interface")
+    }
+
     let baselineABIDir = try getArgumentAsPath("-baseline-abi-dir")
     var driver = try Driver(args: args,
                             diagnosticsOutput: .engine(diagnosticsEngine),


### PR DESCRIPTION
- **Explanation:** As an unintended consequence of https://github.com/swiftlang/swift/pull/72291, this tool has now started to occasionally pick up binary modules from a prebuilt cache, instead of always building new ones from their textual interface. This change uses the new control to force the tool to always build modules from interface when one is available. 

- **Scope:** This change affects the `swift-build-sdk-interfaces` tool and forces it to always rebuild modules from interface, instead of potentially being able to pick-up a prebuilt existing binary module.

- **Risk:** Low. This change is purely additive to force the dependency scanner to the expected behavior for this tool when the underlying compiler supports it.

- **Original PR:** https://github.com/swiftlang/swift-driver/pull/1651

- **Reviewers:** @cachemeifyoucan 