### PR TITLE
[Explicit Module Builds] Remove dead/incorrect code for handling header inputs of binary module dependencies

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -269,12 +269,6 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
       if cas != nil && !prebuiltHeaderDependencyPaths.isEmpty {
         throw DependencyScanningError.unsupportedConfigurationForCaching("module \(dependencyModule.moduleName) has bridging header dependency")
       }
-
-      for headerDep in prebuiltHeaderDependencyPaths {
-        commandLine.appendFlags(["-Xcc", "-include-pch", "-Xcc"])
-        commandLine.appendPath(VirtualPath.lookup(headerDep.path))
-        inputs.append(TypedVirtualPath(file: headerDep.path, type: .pch))
-      }
     }
     for moduleArtifactInfo in clangDependencyArtifacts {
       let clangModulePath =


### PR DESCRIPTION
As of https://github.com/swiftlang/swift/pull/72067, we instead serialize `.h` inputs directly into binary `.swiftmodule` files, because their clients may not be able to use the dependnecies' corresponding `.pch` files due to a compilation context mismatch. The clients of such binary modules then consume the serialized `.h` files directly, and compile them, implicitly, using explicit module dependencies collected during scan of such header files.

Resolves rdar://131261765