### PR TITLE
[6.0 🍒][Explicit Module Builds] Remove dead/incorrect code for handling header inputs of binary module dependencies

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -269,12 +269,6 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
       if cas != nil && !prebuiltHeaderDependencyPaths.isEmpty {
         throw DependencyScanningError.unsupportedConfigurationForCaching("module \(dependencyModule.moduleName) has bridging header dependency")
       }
-
-      for headerDep in prebuiltHeaderDependencyPaths {
-        commandLine.appendFlags(["-Xcc", "-include-pch", "-Xcc"])
-        commandLine.appendPath(VirtualPath.lookup(headerDep.path))
-        inputs.append(TypedVirtualPath(file: headerDep.path, type: .pch))
-      }
     }
     for moduleArtifactInfo in clangDependencyArtifacts {
       let clangModulePath =


### PR DESCRIPTION
- **Explanation:** As of https://github.com/swiftlang/swift/pull/72067, we serialize (bridging) `.h` inputs directly into binary `.swiftmodule` files, because their clients may not be able to use the binary module's corresponding `.pch` files due to a compilation context mismatch. The clients of such binary modules then consume the serialized `.h` files directly, and compile them, implicitly, using explicit module dependencies collected during scan of such header files. This change removes leftover code that relied on a prior, incorrect, assumption that we pass on binary dependencies' PCH inputs to their clients. 
- **Scope:** This affects Explicit Module Builds where source client being compiled depends on a binary-only `.swiftmodule` dependency which was built with a bridging header.
- **Risk:** Low. This change only deletes a code-path that previously was extremely likely to lead to a compilation error downstream.
- **Issue/Radar:** rdar://131261765
- **Original PR:** https://github.com/swiftlang/swift-driver/pull/1653
- **Reviewed By:** @cachemeifyoucan 