### PR TITLE
[6.0 🍒][Test Only] Make `CachingBuildTests.testDependencyScanning` be adaptable to scanner diagnostic revisions

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -823,15 +823,27 @@ final class CachingBuildTests: XCTestCase {
                                       "-cas-path", casPath2.nativePathString(escaped: true),
                                       ]
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
-      XCTAssertThrowsError(try dependencyOracle.getDependencies(workingDirectory: path,
-                                                                commandLine: command,
-                                                                diagnostics: &scanDiagnostics)) {
-        XCTAssertTrue($0 is DependencyScanningError)
+      do {
+        let _ = try dependencyOracle.getDependencies(workingDirectory: path,
+                                                     commandLine: command,
+                                                     diagnostics: &scanDiagnostics)
+      } catch let error {
+        XCTAssertTrue(error is DependencyScanningError)
       }
-      let diags = try XCTUnwrap(dependencyOracle.getScannerDiagnostics())
-      XCTAssertEqual(diags.count, 1)
-      XCTAssertEqual(diags[0].severity, .error)
-      XCTAssertEqual(diags[0].message, "CAS error encountered: conflicting CAS options used in scanning service")
+
+      let testDiagnostics: [ScannerDiagnosticPayload]
+      if try dependencyOracle.supportsPerScanDiagnostics(),
+         !scanDiagnostics.isEmpty {
+        testDiagnostics = scanDiagnostics
+        print("Using Per-Scan diagnostics")
+      } else {
+        testDiagnostics = try XCTUnwrap(dependencyOracle.getScannerDiagnostics())
+        print("Using Scanner-Global diagnostics")
+      }
+
+      XCTAssertEqual(testDiagnostics.count, 1)
+      XCTAssertEqual(testDiagnostics[0].severity, .error)
+      XCTAssertEqual(testDiagnostics[0].message, "CAS error encountered: conflicting CAS options used in scanning service")
     }
   }
 


### PR DESCRIPTION
- **Explanation:** Adapt the test to changing compiler-side infrastructure which may no longer cause the driver to throw an exception on the kind of failure this test is meant to test. Make it handle both new and existing behavior.
- **Scope:** Test-only change.
- **Risk:** None. Test-only change.
- **Original PR:** https://github.com/swiftlang/swift-driver/pull/1658
- **Reviewed By:** @cachemeifyoucan 