### PR TITLE
[6.0] Import new Android overlay or Bionic module

### DIFF
--- a/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
+++ b/Sources/SwiftDriver/Driver/ToolExecutionDelegate.swift
@@ -19,6 +19,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Missing libc or equivalent")
 #endif
@@ -136,7 +138,11 @@ import var TSCBasic.stdoutStream
         }
 #else
       case .signalled(let signal):
+#if canImport(Bionic)
+        let errorMessage = String(cString: strsignal(signal))
+#else
         let errorMessage = strsignal(signal).map { String(cString: $0) } ?? ""
+#endif
         messages = constructJobSignalledMessages(job: job, error: errorMessage, output: output,
                                                  signal: signal, pid: pid).map {
           ParsableMessage(name: job.kind.rawValue, kind: .signalled($0))

--- a/Sources/SwiftDriver/SwiftScan/Loader.swift
+++ b/Sources/SwiftDriver/SwiftScan/Loader.swift
@@ -21,6 +21,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 internal enum Loader {

--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -18,6 +18,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 /// Represents a time point value with nanosecond precision.

--- a/Sources/SwiftDriver/Utilities/System.swift
+++ b/Sources/SwiftDriver/Utilities/System.swift
@@ -16,6 +16,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 func argumentNeedsQuoting(_ argument: String) -> Bool {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -19,6 +19,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 import class TSCBasic.DiagnosticsEngine

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -20,6 +20,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 import Dispatch


### PR DESCRIPTION
__Explanation:__ Now that this new overlay was merged into the 6.0 compiler too in swiftlang/swift#74758, this adds the overlay to the six files that currently `import Glibc` in this repo and fixes a build error because `strsignal()` always returns `_Nonnull` in the latest Android NDK 26.

__Scope:__ Add imports and a build fix on Android only

__Issue:__ None

__Original PR:__ #1647

__Risk:__ None

__Testing:__ Passed all CI on trunk, plus now builds with the new Android overlay on my daily Android CI, finagolfin/swift-android-sdk#156

__Reviewer:__ @compnerd

@artemcm, easy review.