### PR TITLE
Pass through `-module-abi-name` to frontend

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -212,6 +212,7 @@ extension Driver {
     try commandLine.appendLast(.importUnderlyingModule, from: &parsedOptions)
     try commandLine.appendLast(.moduleCachePath, from: &parsedOptions)
     try commandLine.appendLast(.moduleLinkName, from: &parsedOptions)
+    try commandLine.appendLast(.moduleAbiName, from: &parsedOptions)
     try commandLine.appendLast(.nostdimport, from: &parsedOptions)
     try commandLine.appendLast(.parseStdlib, from: &parsedOptions)
     try commandLine.appendLast(.solverMemoryThreshold, from: &parsedOptions)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -827,6 +827,16 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testModuleABIName() throws {
+    var driver = try Driver(
+      args: ["swiftc", "foo.swift", "-module-name", "Mod", "-module-abi-name", "ABIMod"]
+    )
+    let jobs = try driver.planBuild()
+    let compileJob = try jobs.findJob(.compile)
+    XCTAssert(compileJob.commandLine.contains(.flag("-module-abi-name")))
+    XCTAssert(compileJob.commandLine.contains(.flag("ABIMod")))
+  }
+
   func testStandardCompileJobs() throws {
     var driver1 = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-module-name", "Test"])
     let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()


### PR DESCRIPTION
Match the legacy driver and add `-module-abi-name` as a common frontend option.