### PR TITLE
[6.0] Allow enabling embedded Swift without WMO when not generating SIL

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -144,7 +144,8 @@ extension Driver {
       throw ErrorDiagnostics.emitted
     }
 
-    if isEmbeddedEnabled &&
+    // Building embedded Swift requires WMO, unless we're not generating SIL. This allows modes like -index-file to work the same way they do when not using embedded Swift
+    if isEmbeddedEnabled && compilerOutputType?.requiresSILGen == true &&
        (!parsedOptions.hasArgument(.wmo) || !parsedOptions.hasArgument(.wholeModuleOptimization)) {
       diagnosticEngine.emit(.error_need_wmo_embedded)
       throw ErrorDiagnostics.emitted

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -441,6 +441,16 @@ extension FileType {
     }
   }
 
+  /// Returns true if producing the file type requires running SILGen.
+  var requiresSILGen: Bool {
+    switch self {
+    case .swift, .ast, .indexData, .indexUnitOutputPath, .jsonCompilerFeatures, .jsonTargetInfo:
+      return false
+    case .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink, .swiftModule, .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile, .swiftConstValues, .assembly, .raw_sil, .raw_sib, .llvmIR, .llvmBitcode, .diagnostics, .emitModuleDiagnostics, .emitModuleDependencies, .objcHeader, .swiftDeps, .modDepCache, .remap, .importedModules, .tbd, .jsonDependencies, .jsonSwiftArtifacts, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm, .pch, .clangModuleMap, .jsonAPIBaseline, .jsonABIBaseline, .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
+      return true
+    }
+  }
+
   /// Returns true if the type can be cached as output.
   var supportCaching: Bool {
     switch self {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6846,6 +6846,13 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(diags.diagnostics.first!.message.text == Diagnostic.Message.error_need_wmo_embedded.text)
     } catch _ { }
     do {
+      // Indexing embedded Swift code should not require WMO
+      let diags = DiagnosticsEngine()
+      var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-index-file", "-index-file-path", "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-o", "a.out", "-module-name", "main"], diagnosticsEngine: diags)
+      _ = try driver.planBuild()
+      XCTAssertEqual(diags.diagnostics.count, 0)
+    }
+    do {
       let diags = DiagnosticsEngine()
       var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-wmo", "-o", "a.out", "-module-name", "main", "-enable-objc-interop"], diagnosticsEngine: diags)
       _ = try driver.planBuild()


### PR DESCRIPTION
This allows modes like -index-file to work the same way they do when not using embedded Swift

Explanation: Allow compiler modes which don't emit SIL to build embedded Swift without WMO, to facilitate indexing
Scope: Only affects embedded Swift
Risk: Low - makes an existing check more permissive
Original PR: https://github.com/swiftlang/swift-driver/pull/1513
Reviewed By: @artemcm 