### PR TITLE
PrebuiltModuleGen: fail prebuilt module generation job when critical modules failed to build

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -213,7 +213,13 @@ fileprivate class ModuleCompileDelegate: JobExecutionDelegate {
       stderrStream.flush()
     }
     let keyModules = ["Swift", "SwiftUI", "Foundation"]
-    return keyModules.allSatisfy { compiledModules.keys.contains($0) }
+    return keyModules.allSatisfy {
+      if compiledModules.keys.contains($0) {
+        return true
+      }
+      stderrStream.send("Missing critical module: \($0)\n")
+      return false
+    }
   }
 
   public func jobFinished(job: Job, result: ProcessResult, pid: Int) {

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -206,6 +206,9 @@ do {
       if let jsonPath = jsonPath {
         try! delegate.emitJsonOutput(to: jsonPath)
       }
+      if !delegate.checkCriticalModulesGenerated() {
+        exit(1)
+      }
     }
     do {
       try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, nil, continueBuildingAfterErrors: true),


### PR DESCRIPTION
Generating prebuilt modules for critical modules is important because missing them has a bigger impact on the overall build time. This change adds a report of generated modules when the job finishes and fails the prebuilt module job if some selected critical modules were missing.

rdar://132094476