### PR TITLE
Don't plan compileJob if emitModule is all that is needed in a separate job

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -470,12 +470,9 @@ extension Driver {
       assert(backendJobs.count <= 1)
       addCompileJobGroup(CompileJobGroup(compileJob: compile, backendJob: backendJobs.first))
     } else {
-      // TODO: if !canSkipIfOnlyModule {
-      // Some other tools still expect the partial jobs. Bring this check
-      // back once they are updated. rdar://84979778
-
       // We can skip the compile jobs if all we want is a module when it's
       // built separately.
+      if parsedOptions.hasArgument(.driverExplicitModuleBuild), canSkipIfOnlyModule { return }
       let compile = try compileJob(primaryInputs: [primaryInput],
                                    outputType: compilerOutputType,
                                    addJobOutputs: addJobOutputs,

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -2269,6 +2269,44 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
   }
 
+  func testEmitModuleSeparatelyJobs() throws {
+    try withTemporaryDirectory { path in
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
+      let moduleCachePath = path.appending(component: "ModuleCache")
+      try localFileSystem.createDirectory(moduleCachePath)
+      let fileA = path.appending(component: "fileA.swift")
+      try localFileSystem.writeFileContents(fileA, bytes:
+        """
+        public struct A {}
+        """
+      )
+      let fileB = path.appending(component: "fileB.swift")
+      try localFileSystem.writeFileContents(fileB, bytes:
+        """
+        public struct B {}
+        """
+      )
+
+      let outputModule = path.appending(component: "Test.swiftmodule")
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      var driver = try Driver(args: ["swiftc",
+                                     "-explicit-module-build", "-v", "-module-name", "Test",
+                                     "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: true),
+                                     "-emit-module", outputModule.nativePathString(escaped: true),
+                                     "-experimental-emit-module-separately",
+                                     fileA.nativePathString(escaped: true), fileB.nativePathString(escaped: true)] + sdkArgumentsForTesting,
+                              env: ProcessEnv.vars)
+      let jobs = try driver.planBuild()
+      let compileJobs = jobs.filter({ $0.kind == .compile })
+      XCTAssertEqual(compileJobs.count, 0)
+      let emitModuleJob = jobs.filter({ $0.kind == .emitModule })
+      XCTAssertEqual(emitModuleJob.count, 1)
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+    }
+  }
+
 // We only care about prebuilt modules in macOS.
 #if os(macOS)
   func testPrebuiltModuleGenerationJobs() throws {


### PR DESCRIPTION
When the requested output is `-emit-module` and also using `-experimental-emit-module-separately`, do not schedule compileJob for each individual source files since all outputs already satisfied by the separately emit module job. The compileJob will only produce unnecessary outputs like per-file modules and slow down the build.

rdar://84979778