### PR TITLE
[Dependency Scanning] Enable scanner-side up-to-date binary module validation on supporting compilers

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -129,6 +129,10 @@ public extension Driver {
       try commandLine.appendLast(.clangScannerModuleCachePath, from: &parsedOptions)
     }
 
+    if isFrontendArgSupported(.scannerModuleValidation) {
+      commandLine.appendFlag(.scannerModuleValidation)
+    }
+
     if isFrontendArgSupported(.scannerPrefixMap) {
       // construct `-scanner-prefix-mapper` for scanner.
       for (key, value) in prefixMapping {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1710,6 +1710,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
         scannerCommand.removeFirst()
       }
 
+      if driver.isFrontendArgSupported(.scannerModuleValidation) {
+        XCTAssertTrue(scannerCommand.contains("-scanner-module-validation"))
+      }
+
       // Ensure we do not propagate the usual PCH-handling arguments to the scanner invocation
       XCTAssertFalse(scannerCommand.contains("-pch-output-dir"))
       XCTAssertFalse(scannerCommand.contains("Foo.o"))


### PR DESCRIPTION
After ffbae26 landed, it is now safe to enable this behavior for all Explicit Module Builds.