### PR TITLE
Add a C (`@_cdecl`) API for the driver's `getSingleFrontendInvocationFromDriverArguments`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,7 @@ let package = Package(
     /// Driver tests.
     .testTarget(
       name: "SwiftDriverTests",
-      dependencies: ["SwiftDriver", "SwiftDriverExecution", "TestUtilities"]),
+      dependencies: ["SwiftDriver", "SwiftDriverExecution", "TestUtilities", "ToolingTestShim"]),
 
     /// IncrementalImport tests
     .testTarget(
@@ -92,6 +92,11 @@ let package = Package(
       name: "TestUtilities",
       dependencies: ["SwiftDriver", "SwiftDriverExecution"],
       path: "Tests/TestUtilities"),
+
+    .target(
+      name: "ToolingTestShim",
+      dependencies: ["SwiftDriver"],
+      path: "Tests/ToolingTestShim"),
 
     /// The options library.
     .target(
@@ -120,7 +125,7 @@ let package = Package(
       ],
       exclude: ["CMakeLists.txt"]),
 
-    /// The help executable.
+    /// Build SDK Interfaces tool executable.
     .executableTarget(
       name: "swift-build-sdk-interfaces",
       dependencies: ["SwiftDriver", "SwiftDriverExecution"],

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -787,8 +787,8 @@ private extension swiftscan_functions_t {
 
 // TODO: Move to TSC?
 /// Perform an  `action` passing it a `const char **` constructed out of `[String]`
-func withArrayOfCStrings<T>(_ strings: [String],
-                            _ action:  (UnsafeMutablePointer<UnsafePointer<Int8>?>?) -> T) -> T
+@_spi(Testing) public func withArrayOfCStrings<T>(_ strings: [String],
+                                                  _ action:  (UnsafeMutablePointer<UnsafePointer<Int8>?>?) -> T) -> T
 {
   let cstrings = strings.map { strdup($0) } + [nil]
   let unsafeCStrings = cstrings.map { UnsafePointer($0) }

--- a/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
+++ b/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
@@ -17,24 +17,96 @@ import enum TSCBasic.ProcessEnv
 import var TSCBasic.localFileSystem
 import SwiftOptions
 
+//typedef enum {
+//  SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR = 0,
+//  SWIFTDRIVER_TOOLING_DIAGNOSTIC_WARNING = 1,
+//  SWIFTDRIVER_TOOLING_DIAGNOSTIC_REMARK = 2,
+//  SWIFTDRIVER_TOOLING_DIAGNOSTIC_NOTE = 3
+//} swiftdriver_tooling_diagnostic_kind;
+public let SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR: CInt = 0;
+public let SWIFTDRIVER_TOOLING_DIAGNOSTIC_WARNING: CInt = 1;
+public let SWIFTDRIVER_TOOLING_DIAGNOSTIC_REMARK: CInt = 2;
+public let SWIFTDRIVER_TOOLING_DIAGNOSTIC_NOTE: CInt = 3;
+
+@_cdecl("swift_getSingleFrontendInvocationFromDriverArgumentsV2")
+public func getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: UnsafePointer<CChar>,
+                                                             argListCount: CInt,
+                                                             argList: UnsafePointer<UnsafePointer<CChar>?>,
+                                                             action: @convention(c) (CInt, UnsafePointer<UnsafePointer<CChar>?>) -> Bool,
+                                                             diagnosticCallback: @convention(c) (CInt, UnsafePointer<CChar>) -> Void,
+                                                             forceNoOutputs: Bool = false) -> Bool {
+  // Bridge the driver path argument
+  let bridgedDriverPath = String(cString: driverPath)
+
+  // Bridge the argv equivalent
+  let argListBufferPtr = UnsafeBufferPointer<UnsafePointer<CChar>?>(start: argList, count: Int(argListCount))
+  let bridgedArgList = [bridgedDriverPath] + argListBufferPtr.map { String(cString: $0!) }
+
+  // Bridge the action callback
+  let bridgedAction: ([String]) -> Bool = { args in
+    return withArrayOfCStrings(args) {
+      return action(CInt(args.count), $0!)
+    }
+  }
+
+  // Bridge the diagnostic callback
+  let bridgedDiagnosticCallback: (CInt, String) -> Void = { diagKind, message in
+    diagnosticCallback(diagKind, message)
+  }
+
+  var diagnostics: [Diagnostic] = []
+  let result = getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: bridgedDriverPath,
+                                                                argList: bridgedArgList,
+                                                                action: bridgedAction,
+                                                                diagnostics: &diagnostics,
+                                                                diagnosticCallback: bridgedDiagnosticCallback,
+                                                                forceNoOutputs: forceNoOutputs)
+  return result
+}
+
 /// Generates the list of arguments that would be passed to the compiler
-/// frontend from the given driver arguments.
+/// frontend from the given driver arguments, for a single-compiler-invocation
+/// context.
 ///
-/// \param ArgList The driver arguments (i.e. normal arguments for \c swiftc).
-/// \param ForceNoOutputs If true, override the output mode to "-typecheck" and
+/// \param driverPath the driver executable path
+/// \param argList The driver arguments (i.e. normal arguments for \c swiftc).
+/// \param diagnostics Contains the diagnostics emitted by the driver
+/// \param action invokes a user-provided action on the resulting frontend invocation command
+/// \param forceNoOutputs If true, override the output mode to "-typecheck" and
 /// produce no outputs. For example, this disables "-emit-module" and "-c" and
 /// prevents the creation of temporary files.
-/// \param outputFrontendArgs Contains the resulting frontend invocation command
-/// \param emittedDiagnostics Contains the diagnostics emitted by the driver
 ///
 /// \returns true on error
 ///
 /// \note This function is not intended to create invocations which are
 /// suitable for use in REPL or immediate modes.
-public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
-                                                           outputFrontendArgs: inout [String],
-                                                           emittedDiagnostics: inout [Diagnostic],
-                                                           forceNoOutputs: Bool = false) -> Bool {
+public func getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: String,
+                                                             argList: [String],
+                                                             action: ([String]) -> Bool,
+                                                             diagnostics: inout [Diagnostic],
+                                                             diagnosticCallback:  @escaping (CInt, String) -> Void,
+                                                             forceNoOutputs: Bool = false) -> Bool {
+  /// Handler for emitting diagnostics to tooling clients.
+  let toolingDiagnosticsHandler: DiagnosticsEngine.DiagnosticsHandler = { diagnostic in
+    let diagnosticKind: CInt
+    switch diagnostic.message.behavior {
+    case .error:
+      diagnosticKind = SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR
+    case .warning:
+      diagnosticKind = SWIFTDRIVER_TOOLING_DIAGNOSTIC_WARNING
+    case .note:
+      diagnosticKind = SWIFTDRIVER_TOOLING_DIAGNOSTIC_NOTE
+    case .remark:
+      diagnosticKind = SWIFTDRIVER_TOOLING_DIAGNOSTIC_REMARK
+    default:
+      diagnosticKind = SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR
+    }
+    diagnosticCallback(diagnosticKind, diagnostic.message.text)
+  }
+  let diagnosticsEngine = DiagnosticsEngine(handlers: [toolingDiagnosticsHandler])
+  defer { diagnostics = diagnosticsEngine.diagnostics }
+
+  var singleFrontendTaskCommand: [String] = []
   var args: [String] = []
   args.append(contentsOf: argList)
 
@@ -55,13 +127,10 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
   args.append("-driver-filelist-threshold");
   args.append(String(Int.max));
 
-  let diagnosticsEngine = DiagnosticsEngine()
-  defer { emittedDiagnostics = diagnosticsEngine.diagnostics }
-
   do {
-    args = try ["swiftc"] + Driver.expandResponseFiles(args,
-                                                       fileSystem: localFileSystem,
-                                                       diagnosticsEngine: diagnosticsEngine)
+    args = try [driverPath] + Driver.expandResponseFiles(args,
+                                                         fileSystem: localFileSystem,
+                                                         diagnosticsEngine: diagnosticsEngine)
 
     let optionTable = OptionTable()
     var parsedOptions = try optionTable.parse(Array(args), for: .batch, delayThrows: true)
@@ -84,7 +153,6 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
       return true
     }
 
-
     let buildPlan = try driver.planBuild()
     if diagnosticsEngine.hasErrors {
       return true
@@ -98,12 +166,12 @@ public func getSingleFrontendInvocationFromDriverArguments(argList: [String],
       diagnosticsEngine.emit(.error_expected_frontend_command())
       return true
     }
-    outputFrontendArgs = try executor.description(of: compileJob,
-                                                  forceResponseFiles: false).components(separatedBy: " ")
+    singleFrontendTaskCommand = try executor.description(of: compileJob,
+                                                         forceResponseFiles: false).components(separatedBy: " ")
   } catch {
     print("Unexpected error: \(error).")
     return true
   }
 
-  return false
+  return action(singleFrontendTaskCommand)
 }

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -9,10 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-import SwiftDriver
+@_spi(Testing) import SwiftDriver
 import SwiftOptions
 import TSCBasic
 import XCTest
+import CToolingTestShim
 
 final class SwiftDriverToolingInterfaceTests: XCTestCase {
   func testCreateCompilerInvocation() throws {
@@ -23,44 +24,53 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
       // Expected success scenarios:
       do {
         let testCommand = inputFile.description
-        var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
-        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
-                                                                      outputFrontendArgs: &resultingFrontendArgs,
-                                                                      emittedDiagnostics: &emittedDiagnostics))
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in }))
       }
       do {
         let testCommand = "-emit-executable " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header -o t.out"
-        var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
-        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
-                                                                      outputFrontendArgs: &resultingFrontendArgs,
-                                                                      emittedDiagnostics: &emittedDiagnostics))
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in }))
       }
       do {
         let testCommand = "-c " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header"
-        var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
-        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
-                                                                      outputFrontendArgs: &resultingFrontendArgs,
-                                                                      emittedDiagnostics: &emittedDiagnostics))
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in }))
       }
       do {
         let testCommand = inputFile.description + " -enable-batch-mode"
-        var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
-        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
-                                                                      outputFrontendArgs: &resultingFrontendArgs,
-                                                                      emittedDiagnostics: &emittedDiagnostics))
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in }))
       }
       do { // Force no outputs
         let testCommand = "-module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
         var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
-        XCTAssertFalse(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
-                                                                      outputFrontendArgs: &resultingFrontendArgs,
-                                                                      emittedDiagnostics: &emittedDiagnostics,
-                                                                      forceNoOutputs: true))
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { args in
+                                                                          resultingFrontendArgs = args
+                                                                          return false
+                                                                        },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in },
+                                                                        forceNoOutputs: true))
         XCTAssertFalse(resultingFrontendArgs.contains("-emit-module-interface-path"))
         XCTAssertFalse(resultingFrontendArgs.contains("-emit-objc-header"))
         XCTAssertFalse(resultingFrontendArgs.contains("-emit-objc-header-path"))
@@ -71,13 +81,77 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
       // Expected failure scenarios:
       do {
         let testCommand = "-v" // No inputs
-        var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
-        XCTAssertTrue(getSingleFrontendInvocationFromDriverArguments(argList: testCommand.components(separatedBy: " "),
-                                                                     outputFrontendArgs: &resultingFrontendArgs,
-                                                                     emittedDiagnostics: &emittedDiagnostics))
+        XCTAssertTrue(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
+                                                                       argList: testCommand.components(separatedBy: " "),
+                                                                       action: { _ in false },
+                                                                       diagnostics: &emittedDiagnostics,
+                                                                       diagnosticCallback: {_,_ in }))
         let errorMessage = try XCTUnwrap(emittedDiagnostics.first?.message.text)
         XCTAssertEqual(errorMessage, "unable to handle compilation, expected exactly one frontend job")
+      }
+    }
+  }
+
+  func testCreateCompilerInvocationCAPI() throws {
+    try withTemporaryDirectory { path in
+      let inputFile = path.appending(components: "test.swift")
+      try localFileSystem.writeFileContents(inputFile) { $0.send("public func foo()") }
+      let driverPath = "swiftc"
+
+      // Basic compilation test
+      do {
+        let testCommandStr = "-emit-executable " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header -o t.out"
+        let testCommand = testCommandStr.split(separator: " ").compactMap { String($0) }
+
+        // Invoke the C shim from CToolingTestShim which calls the `getSingleFrontendInvocationFromDriverArgumentsV2`
+        // C API defined in Swift in ToolingUtil
+        XCTAssertFalse(driverPath.withCString { CBridgedDriverPath in
+          withArrayOfCStrings(testCommand) { CBridgedArgList in
+            getSingleFrontendInvocationFromDriverArgumentsTest(
+              CBridgedDriverPath,
+              CInt(testCommand.count),
+              CBridgedArgList!,
+              { argc, argvPtr in
+                // Bridge argc back to [String]
+                let argvBufferPtr = UnsafeBufferPointer<UnsafePointer<CChar>?>(start: argvPtr, count: Int(argc))
+                let resultingFrontendArgs = argvBufferPtr.map { String(cString: $0!) }
+                print(resultingFrontendArgs)
+                XCTAssertTrue(resultingFrontendArgs.contains("-frontend"))
+                XCTAssertTrue(resultingFrontendArgs.contains("-c"))
+                XCTAssertTrue(resultingFrontendArgs.contains("-emit-module-path"))
+                XCTAssertTrue(resultingFrontendArgs.contains("-o"))
+                return false
+              },
+              { diagKind, diagMessage in },
+              false)
+          }
+        })
+      }
+
+      // Diagnostic callback test
+      do {
+        let testCommandStr = "-v"
+        let testCommand = testCommandStr.split(separator: " ").compactMap { String($0) }
+        XCTAssertTrue(driverPath.withCString { CBridgedDriverPath in
+          withArrayOfCStrings(testCommand) { CBridgedArgList in
+            getSingleFrontendInvocationFromDriverArgumentsTest(
+              CBridgedDriverPath,
+              CInt(testCommand.count),
+              CBridgedArgList!,
+              { argc, argvPtr in false },
+              { diagKind, diagMessage in
+                guard let nonOptionalDiagMessage = diagMessage else {
+                  XCTFail("Invalid tooling diagnostic handler message")
+                  return
+                }
+                XCTAssertEqual(diagKind, SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR)
+                XCTAssertEqual(String(cString: nonOptionalDiagMessage),
+                               "unable to handle compilation, expected exactly one frontend job")
+              },
+              false)
+          }
+        })
       }
     }
   }

--- a/Tests/ToolingTestShim/CMakeLists.txt
+++ b/Tests/ToolingTestShim/CMakeLists.txt
@@ -1,0 +1,10 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(CToolingTestShim STATIC
+            CToolingTestShimImpl.c)

--- a/Tests/ToolingTestShim/CToolingTestShimImpl.c
+++ b/Tests/ToolingTestShim/CToolingTestShimImpl.c
@@ -1,0 +1,14 @@
+#include "include/tooling_shim.h"
+
+bool swift_getSingleFrontendInvocationFromDriverArgumentsV2(const char *, int, const char**, bool(int, const char**),
+                                                      void(swiftdriver_tooling_diagnostic_kind, const char*), bool);
+bool getSingleFrontendInvocationFromDriverArgumentsTest(const char *driverPath,
+                                                        int argListCount,
+                                                        const char** argList,
+                                                        bool action(int argc, const char** argv),
+                                                        void diagnosticCallback(swiftdriver_tooling_diagnostic_kind diagnosticKind,
+                                                                                const char* message),
+                                                        bool forceNoOutputs) {
+  return swift_getSingleFrontendInvocationFromDriverArgumentsV2(driverPath, argListCount, argList,
+                                                                action, diagnosticCallback, forceNoOutputs);
+}

--- a/Tests/ToolingTestShim/include/module.modulemap
+++ b/Tests/ToolingTestShim/include/module.modulemap
@@ -1,0 +1,4 @@
+module CToolingTestShim {
+  header "tooling_shim.h"
+  export *
+}

--- a/Tests/ToolingTestShim/include/tooling_shim.h
+++ b/Tests/ToolingTestShim/include/tooling_shim.h
@@ -1,0 +1,38 @@
+//=== tooling_shim.h - C API Shim for Swift Driver Tooling Testing *- C -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_C_TOOLING_TEST_SHIM_H
+#define SWIFT_C_TOOLING_TEST_SHIM_H
+
+#if __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+
+typedef enum {
+  SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR = 0,
+  SWIFTDRIVER_TOOLING_DIAGNOSTIC_WARNING = 1,
+  SWIFTDRIVER_TOOLING_DIAGNOSTIC_REMARK = 2,
+  SWIFTDRIVER_TOOLING_DIAGNOSTIC_NOTE = 3
+} swiftdriver_tooling_diagnostic_kind;
+
+// A shim that will call out to the Swift-written C API of swift_getSingleFrontendInvocationFromDriverArgumentsV2
+bool getSingleFrontendInvocationFromDriverArgumentsTest(const char *, int, const char**, bool(int, const char**),
+                                                        void(swiftdriver_tooling_diagnostic_kind, const char*), bool);
+
+#if __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif // SWIFT_C_TOOLING_TEST_SHIM_H


### PR DESCRIPTION
This will enable non-Swift clients to query this utility as an alternative to the legacy C++ driver's equivalent.