### PR TITLE
Fix ExplicitModuleBuildTests: `testExplicitLinkLibraries` & `testDependencyGraphDotSerialization` &  CachingBuildTests: `testSeparateModuleJob` & `testModuleOnlyJob`

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -227,7 +227,7 @@ final class CachingBuildTests: XCTestCase {
       let casPath = path.appending(component: "cas")
       let swiftModuleInterfacesPath: AbsolutePath =
           try testInputsPath.appending(component: "ExplicitModuleBuilds")
-                            .appending(component: "Swift")      
+                            .appending(component: "Swift")
       let cHeadersPath: AbsolutePath =
           try testInputsPath.appending(component: "ExplicitModuleBuilds")
                             .appending(component: "CHeaders")
@@ -337,6 +337,7 @@ final class CachingBuildTests: XCTestCase {
   }
 
   func testModuleOnlyJob() throws {
+    let (stdlibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testModuleOnlyJob.swift")
       try localFileSystem.writeFileContents(main) {
@@ -358,10 +359,11 @@ final class CachingBuildTests: XCTestCase {
       let modulePath: AbsolutePath = path.appending(component: "testModuleOnlyJob.swiftmodule")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-target", "x86_64-apple-macosx11.0",
                                      "-module-name", "Test",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+				     "-I", stdlibPath.nativePathString(escaped: true),
+                                     "-I", shimsPath.nativePathString(escaped: true),
                                      "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
                                      "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: true),
                                      "-explicit-module-build", "-emit-module-separately-wmo", "-disable-cmo", "-Rcache-compile-job",
@@ -393,6 +395,7 @@ final class CachingBuildTests: XCTestCase {
   }
 
   func testSeparateModuleJob() throws {
+    let (stdlibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testSeparateModuleJob.swift")
       try localFileSystem.writeFileContents(main) {
@@ -410,16 +413,19 @@ final class CachingBuildTests: XCTestCase {
       let modulePath: AbsolutePath = path.appending(component: "testSeparateModuleJob.swiftmodule")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
-                                     "-target", "x86_64-apple-macosx11.0",
                                      "-module-name", "Test",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
+				     "-I", stdlibPath.nativePathString(escaped: true),
+                                     "-I", shimsPath.nativePathString(escaped: true),
                                      "-emit-module-path", modulePath.nativePathString(escaped: true),
                                      "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
                                      "-emit-private-module-interface-path", privateSwiftInterfacePath.nativePathString(escaped: true),
                                      "-explicit-module-build", "-experimental-emit-module-separately", "-Rcache-compile-job",
                                      "-enable-library-evolution", "-O",
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
+				     "-Xfrontend", "-disable-implicit-concurrency-module-import",
+				     "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -112,6 +112,60 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
   }
 }
 
+internal func getDriverArtifactsForScanning() throws -> (stdLibPath: AbsolutePath,
+                                                         shimsPath: AbsolutePath,
+                                                         toolchain: Toolchain,
+                                                         hostTriple: Triple) {
+  // Just instantiating to get at the toolchain path
+  let driver = try Driver(args: ["swiftc", "-explicit-module-build",
+                                 "-module-name", "testDependencyScanning",
+                                 "test.swift"])
+  let (stdLibPath, shimsPath) = try getStdlibShimsPaths(driver)
+  XCTAssertTrue(localFileSystem.exists(stdLibPath),
+                "expected Swift StdLib at: \(stdLibPath.description)")
+  XCTAssertTrue(localFileSystem.exists(shimsPath),
+                "expected Swift Shims at: \(shimsPath.description)")
+  return (stdLibPath, shimsPath, driver.toolchain, driver.hostTriple)
+}
+
+func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath) {
+  let toolchainRootPath: AbsolutePath = try driver.toolchain.getToolPath(.swiftCompiler)
+                                                          .parentDirectory // bin
+                                                          .parentDirectory // toolchain root
+  if driver.targetTriple.isDarwin {
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+                                           processSet: ProcessSet(),
+                                           fileSystem: localFileSystem,
+                                           env: ProcessEnv.vars)
+    let sdkPath = try executor.checkNonZeroExit(
+      args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
+    let stdLibPath = try AbsolutePath(validating: sdkPath).appending(component: "usr")
+      .appending(component: "lib")
+      .appending(component: "swift")
+    return (stdLibPath, stdLibPath.appending(component: "shims"))
+  } else if driver.targetTriple.isWindows {
+    if let sdkroot = try driver.toolchain.defaultSDKPath(driver.targetTriple) {
+      return (sdkroot.appending(components: "usr", "lib", "swift", "windows"),
+              sdkroot.appending(components: "usr", "lib", "swift", "shims"))
+    }
+    return (toolchainRootPath
+              .appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: driver.targetTriple.osNameUnversioned),
+            toolchainRootPath
+              .appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: "shims"))
+  } else {
+    return (toolchainRootPath.appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: driver.targetTriple.osNameUnversioned),
+            toolchainRootPath.appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: "shims"))
+  }
+}
+
 /// Test that for the given JSON module dependency graph, valid jobs are generated
 final class ExplicitModuleBuildTests: XCTestCase {
   func testModuleDependencyBuildCommandGeneration() throws {
@@ -1335,60 +1389,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Ensure the dependency has been reported as a framework
       XCTAssertTrue(fooDetails.isFramework)
     }
-  }
-
-  func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath) {
-    let toolchainRootPath: AbsolutePath = try driver.toolchain.getToolPath(.swiftCompiler)
-                                                            .parentDirectory // bin
-                                                            .parentDirectory // toolchain root
-    if driver.targetTriple.isDarwin {
-      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
-                                             processSet: ProcessSet(),
-                                             fileSystem: localFileSystem,
-                                             env: ProcessEnv.vars)
-      let sdkPath = try executor.checkNonZeroExit(
-        args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
-      let stdLibPath = try AbsolutePath(validating: sdkPath).appending(component: "usr")
-        .appending(component: "lib")
-        .appending(component: "swift")
-      return (stdLibPath, stdLibPath.appending(component: "shims"))
-    } else if driver.targetTriple.isWindows {
-      if let sdkroot = try driver.toolchain.defaultSDKPath(driver.targetTriple) {
-        return (sdkroot.appending(components: "usr", "lib", "swift", "windows"),
-                sdkroot.appending(components: "usr", "lib", "swift", "shims"))
-      }
-      return (toolchainRootPath
-                .appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: driver.targetTriple.osNameUnversioned),
-              toolchainRootPath
-                .appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: "shims"))
-    } else {
-      return (toolchainRootPath.appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: driver.targetTriple.osNameUnversioned),
-              toolchainRootPath.appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: "shims"))
-    }
-  }
-
-  private func getDriverArtifactsForScanning() throws -> (stdLibPath: AbsolutePath,
-                                                          shimsPath: AbsolutePath,
-                                                          toolchain: Toolchain,
-                                                          hostTriple: Triple) {
-    // Just instantiating to get at the toolchain path
-    let driver = try Driver(args: ["swiftc", "-explicit-module-build",
-                                   "-module-name", "testDependencyScanning",
-                                   "test.swift"])
-    let (stdLibPath, shimsPath) = try getStdlibShimsPaths(driver)
-    XCTAssertTrue(localFileSystem.exists(stdLibPath),
-                  "expected Swift StdLib at: \(stdLibPath.description)")
-    XCTAssertTrue(localFileSystem.exists(shimsPath),
-                  "expected Swift Shims at: \(shimsPath.description)")
-    return (stdLibPath, shimsPath, driver.toolchain, driver.hostTriple)
   }
 
   /// Test the libSwiftScan dependency scanning (import-prescan).

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -391,9 +391,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       let checkForLinkLibrary = { (info: ModuleInfo, linkName: String, isFramework: Bool, shouldForceLoad: Bool) in
         let linkLibraries = try XCTUnwrap(info.linkLibraries)
-        XCTAssertEqual(linkLibraries.count, 1)
-        let linkLibrary = try XCTUnwrap(linkLibraries.first)
-        XCTAssertEqual(linkLibrary.linkName, linkName)
+        let linkLibrary = try XCTUnwrap(linkLibraries.first { $0.linkName == linkName })
         XCTAssertEqual(linkLibrary.isFramework, isFramework)
         XCTAssertEqual(linkLibrary.shouldForceLoad, shouldForceLoad)
       }
@@ -2090,9 +2088,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
         XCTAssertTrue(contents.contains("\"G\" [style=bold, color=orange"))
         XCTAssertTrue(contents.contains("\"E\" [style=bold, color=orange, style=filled"))
         XCTAssertTrue(contents.contains("\"C (C)\" [style=bold, color=lightskyblue, style=filled"))
-        XCTAssertTrue(contents.contains("\"Swift\" [style=bold, color=orange, style=filled"))
+        XCTAssertTrue(contents.contains("\"Swift\" [style=bold, color=orange, style=filled") ||
+                      contents.contains("\"Swift (Prebuilt)\" [style=bold, color=darkorange3, style=filled"))
         XCTAssertTrue(contents.contains("\"SwiftShims (C)\" [style=bold, color=lightskyblue, style=filled"))
-        XCTAssertTrue(contents.contains("\"Swift\" -> \"SwiftShims (C)\" [color=black];"))
+        XCTAssertTrue(contents.contains("\"Swift\" -> \"SwiftShims (C)\" [color=black];") ||
+	              contents.contains("\"Swift (Prebuilt)\" -> \"SwiftShims (C)\" [color=black];"))
       }
   }
 
@@ -2237,7 +2237,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let moduleCachePath = path.appending(component: "ModuleCache")
       try localFileSystem.createDirectory(moduleCachePath)
       let main = path.appending(component: "testTraceDependency.swift")
-      try localFileSystem.writeFileContents(main, bytes: 
+      try localFileSystem.writeFileContents(main, bytes:
         """
         import C;\
         import E;\


### PR DESCRIPTION
- `testExplicitLinkLibraries` to account for possibility of multiple link libraries per dependency
- `testDependencyGraphDotSerialization` to account for possibility of discovering prebuilt modules for stdlib
- `testSeparateModuleJob` & `testModuleOnlyJob`: Do not always hard-code a macOS triple and pass in explicit stdlib paths to the driver invocations