### PR TITLE
SwiftDriver: forward `-sysroot` provided by the user

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -218,9 +218,12 @@ extension GenericUnixToolchain {
       }
 
       if targetTriple.environment == .android {
-        if let sysroot = try getAndroidNDKSysrootPath() {
-          commandLine.appendFlag("--sysroot")
-          commandLine.appendPath(sysroot)
+        if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
+          commandLine.appendFlag("-sysroot")
+          try commandLine.appendPath(VirtualPath(path: sysroot))
+        } else if let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env) {
+          commandLine.appendFlag("-sysroot")
+          try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
         }
       } else if let path = targetInfo.sdkPath?.path {
         commandLine.appendFlag("--sysroot")

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -14,6 +14,34 @@ import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
 import var TSCBasic.localFileSystem
 
+internal enum AndroidNDK {
+  internal static func getOSName() -> String? {
+    // The NDK is only available on macOS, linux and windows hosts currently.
+#if os(Windows)
+    "windows"
+#elseif os(Linux)
+    "linux"
+#elseif os(macOS)
+    "darwin"
+#else
+    nil
+#endif
+  }
+
+  internal static func getDefaultSysrootPath(in env: [String:String]) -> AbsolutePath? {
+    // The NDK is only available on an x86_64 hosts currently.
+#if arch(x86_64)
+    guard let ndk = env["ANDROID_NDK_ROOT"], let os = getOSName() else { return nil }
+    return try? AbsolutePath(validating: ndk)
+      .appending(components: "toolchains", "llvm", "prebuilt")
+      .appending(component: "\(os)-x86_64")
+      .appending(component: "sysroot")
+#else
+    return nil
+#endif
+  }
+}
+
 /// Toolchain for Unix-like systems.
 public final class GenericUnixToolchain: Toolchain {
   public let env: [String: String]
@@ -118,38 +146,6 @@ public final class GenericUnixToolchain: Toolchain {
     return "libclang_rt.\(sanitizer.libraryName)-\(targetTriple.archName)\(environment).a"
   }
 
-  private func getAndroidNDKHostOSSuffix() -> String? {
-#if os(Windows)
-    "windows"
-#elseif os(Linux)
-    "linux"
-#elseif os(macOS)
-    "darwin"
-#else
-    // The NDK is only available on macOS, linux and windows hosts.
-    nil
-#endif
-  }
-
-  func getAndroidNDKSysrootPath() throws -> AbsolutePath? {
-#if arch(x86_64)
-    // The NDK's sysroot should be specified in the environment.
-    guard let ndk = env["ANDROID_NDK_ROOT"],
-          let osSuffix = getAndroidNDKHostOSSuffix() else {
-      return  nil
-    }
-    var sysroot: AbsolutePath =
-        try AbsolutePath(validating: ndk)
-            .appending(components: "toolchains", "llvm", "prebuilt")
-            .appending(component: "\(osSuffix)-x86_64")
-            .appending(component: "sysroot")
-    return sysroot
-#else
-    // The NDK is only available on an x86_64 host.
-    return nil
-#endif
-  }
-
   public func addPlatformSpecificCommonFrontendOptions(
     commandLine: inout [Job.ArgTemplate],
     inputs: inout [TypedVirtualPath],
@@ -157,9 +153,12 @@ public final class GenericUnixToolchain: Toolchain {
     driver: inout Driver
   ) throws {
     if driver.targetTriple.environment == .android {
-      if let sysroot = try getAndroidNDKSysrootPath() {
+      if let sysroot = driver.parsedOptions.getLastArgument(.sysroot)?.asSingle {
         commandLine.appendFlag("-sysroot")
-        commandLine.appendFlag(sysroot.pathString)
+        try commandLine.appendPath(VirtualPath(path: sysroot))
+      } else if let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env) {
+        commandLine.appendFlag("-sysroot")
+        try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
       }
     }
   }


### PR DESCRIPTION
This addresses a missing component of the initial Android support. When the user specifies `-sysroot`, that should always be given precedence as it is explicitly specified by the user. The `ANDROID_NDK_ROOT` environment variable is set by the Android NDK and is used as a _default_ value in the scenario that the user does not specify the `-sysroot` option. This makes Android both behave more like the Windows platform and also ensures that the user has full control over the behaviour of the toolchain.

Take the opportunity to refactor some of the code to extract the Android NDK specific helpers into an uninhabited enum and provide some behavioural test cases.