### PR TITLE
Android: add the right suffix for the compiler-rt profiler library

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -285,9 +285,10 @@ extension GenericUnixToolchain {
       }
 
       if parsedOptions.hasArgument(.profileGenerate) {
+        let environment = (targetTriple.environment == .android) ? "-android" : ""
         let libProfile = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
           .appending(components: "clang", "lib", targetTriple.osName,
-                                 "libclang_rt.profile-\(targetTriple.archName).a")
+                                 "libclang_rt.profile-\(targetTriple.archName)\(environment).a")
         commandLine.appendPath(libProfile)
 
         // HACK: Hard-coded from llvm::getInstrProfRuntimeHookVarName()


### PR DESCRIPTION
A bunch of profiler tests in the compiler validation suite were recently enabled on non-Darwin platforms by swiftlang/swift#75572 and then failed natively on Android because they couldn't find this profiler library, which this pull fixed. This is [the same change I used to find the sanitizer libraries for Android a couple years ago](https://github.com/swiftlang/swift-driver/pull/720/files#diff-b2b6d2b2cf451a616f869ff28282d9fb3bbf966edeb03abfa7c47f12b6851377R109).