### PR TITLE
[cxx-interop] Remove `-experimental-cxx-stdlib` flag

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -136,9 +136,6 @@ extension Driver {
     // Add flags for C++ interop
     try commandLine.appendLast(.enableExperimentalCxxInterop, from: &parsedOptions)
     try commandLine.appendLast(.cxxInteroperabilityMode, from: &parsedOptions)
-    if let stdlibVariant = parsedOptions.getLastArgument(.experimentalCxxStdlib)?.asSingle {
-      appendXccFlag("-stdlib=\(stdlibVariant)")
-    }
 
     if isEmbeddedEnabled && parsedOptions.hasArgument(.enableLibraryEvolution) {
       diagnosticEngine.emit(.error_no_library_evolution_embedded)

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -202,10 +202,6 @@ extension WindowsToolchain {
       commandLine.appendPath(VirtualPath.lookup(sdkPath))
     }
 
-    if let stdlib = parsedOptions.getLastArgument(.experimentalCxxStdlib) {
-      commandLine.appendFlag("-stdlib=\(stdlib.asSingle)")
-    }
-
     // Pass down an optimization level
     if let optArg = mapOptimizationLevelToClangArg(from: &parsedOptions) {
       commandLine.appendFlag(optArg)

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -165,7 +165,6 @@ public final class DarwinToolchain: Toolchain {
     case argumentNotSupported(String)
     case invalidDeploymentTargetForIR(platform: DarwinPlatform, version: Triple.Version, archName: String)
     case unsupportedTargetVariant(variant: Triple)
-    case darwinOnlySupportsLibCxx
 
     public var description: String {
       switch self {
@@ -177,8 +176,6 @@ public final class DarwinToolchain: Toolchain {
         return "unsupported '\(variant.isiOS ? "-target-variant" : "-target")' value '\(variant.triple)'; use 'ios-macabi' instead"
       case .argumentNotSupported(let argument):
         return "\(argument) is no longer supported for Apple platforms"
-      case .darwinOnlySupportsLibCxx:
-        return "The only C++ standard library supported on Apple platforms is libc++"
       }
     }
   }
@@ -210,12 +207,6 @@ public final class DarwinToolchain: Toolchain {
     // Validating darwin unsupported -static-executable argument.
     if parsedOptions.hasArgument(.staticExecutable) {
       throw ToolchainValidationError.argumentNotSupported("-static-executable")
-    }
-    // If a C++ standard library is specified, it has to be libc++.
-    if let cxxLib = parsedOptions.getLastArgument(.experimentalCxxStdlib) {
-        if cxxLib.asSingle != "libc++" {
-            throw ToolchainValidationError.darwinOnlySupportsLibCxx
-        }
     }
   }
 

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -478,7 +478,6 @@ extension Option {
   public static let experimentalAllowedReexportedModules: Option = Option("-experimental-allowed-reexported-modules=", .commaJoined, attributes: [.noDriver], helpText: "Allow reexporting symbols from the provided modules if they are themselves exported from the main module. This is a comma separated list of module names.")
   public static let experimentalCForeignReferenceTypes: Option = Option("-experimental-c-foreign-reference-types", .flag, attributes: [.helpHidden, .frontend, .moduleInterface], helpText: "Enable experimental C foreign references types (with reference counting).")
   public static let experimentalClangImporterDirectCc1Scan: Option = Option("-experimental-clang-importer-direct-cc1-scan", .flag, attributes: [.helpHidden, .frontend], helpText: "Enables swift driver to construct swift-frontend invocations using -direct-clang-cc1-module-build")
-  public static let experimentalCxxStdlib: Option = Option("-experimental-cxx-stdlib", .separate, attributes: [.helpHidden], helpText: "C++ standard library to use; forwarded to Clang's -stdlib flag")
   public static let emitModuleSeparately: Option = Option("-experimental-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Emit module files as a distinct job")
   public static let driverExperimentalExplicitModuleBuild: Option = Option("-experimental-explicit-module-build", .flag, alias: Option.driverExplicitModuleBuild, attributes: [.helpHidden], helpText: "Prebuild module dependencies to make them explicit")
   public static let forceWorkaroundBrokenModules: Option = Option("-experimental-force-workaround-broken-modules", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Attempt unsafe recovery for imported modules with broken modularization")
@@ -1351,7 +1350,6 @@ extension Option {
       Option.experimentalAllowedReexportedModules,
       Option.experimentalCForeignReferenceTypes,
       Option.experimentalClangImporterDirectCc1Scan,
-      Option.experimentalCxxStdlib,
       Option.emitModuleSeparately,
       Option.driverExperimentalExplicitModuleBuild,
       Option.forceWorkaroundBrokenModules,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4281,14 +4281,6 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
-    XCTAssertThrowsError(try Driver(args: ["swiftc", "-c", "-target", "x86_64-apple-macosx10.14", "-experimental-cxx-stdlib", "libstdc++",
-                                           "foo.swift"])) { error in
-        guard case DarwinToolchain.ToolchainValidationError.darwinOnlySupportsLibCxx = error else {
-          XCTFail("Unexpected error: \(error)")
-        return
-      }
-    }
-
     // Not actually a valid arch for tvOS, but we shouldn't fall into the iOS case by mistake and emit a message about iOS >= 11 not supporting armv7.
     XCTAssertNoThrow(try Driver(args: ["swiftc", "-c", "-target", "armv7-apple-tvos9.0", "foo.swift"]))
 
@@ -6822,19 +6814,6 @@ final class SwiftDriverTests: XCTestCase {
       let compileJob = plannedJobs[0]
       let linkJob = plannedJobs[1]
       XCTAssertTrue(compileJob.commandLine.contains(.flag("-cxx-interoperability-mode=swift-5.9")))
-      if driver.targetTriple.isDarwin {
-        XCTAssertTrue(linkJob.commandLine.contains(.flag("-lc++")))
-      }
-    }
-    do {
-      var driver = try Driver(args: ["swiftc", "-cxx-interoperability-mode=swift-5.9",
-                                     "-experimental-cxx-stdlib", "libc++", "foo.swift"])
-      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
-      XCTAssertEqual(plannedJobs.count, 2)
-      let compileJob = plannedJobs[0]
-      let linkJob = plannedJobs[1]
-      XCTAssertTrue(compileJob.commandLine.contains(.flag("-cxx-interoperability-mode=swift-5.9")))
-      XCTAssertTrue(compileJob.commandLine.contains(.flag("-stdlib=libc++")))
       if driver.targetTriple.isDarwin {
         XCTAssertTrue(linkJob.commandLine.contains(.flag("-lc++")))
       }


### PR DESCRIPTION
This change is a counterpart of https://github.com/swiftlang/swift/pull/76280.