### PR TITLE
[6.0 🍒] Fix CachingBuildTests: testSeparateModuleJob & testModuleOnlyJob

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -112,6 +112,60 @@ private func checkExplicitModuleBuildJobDependencies(job: Job,
   }
 }
 
+internal func getDriverArtifactsForScanning() throws -> (stdLibPath: AbsolutePath,
+                                                         shimsPath: AbsolutePath,
+                                                         toolchain: Toolchain,
+                                                         hostTriple: Triple) {
+  // Just instantiating to get at the toolchain path
+  let driver = try Driver(args: ["swiftc", "-explicit-module-build",
+                                 "-module-name", "testDependencyScanning",
+                                 "test.swift"])
+  let (stdLibPath, shimsPath) = try getStdlibShimsPaths(driver)
+  XCTAssertTrue(localFileSystem.exists(stdLibPath),
+                "expected Swift StdLib at: \(stdLibPath.description)")
+  XCTAssertTrue(localFileSystem.exists(shimsPath),
+                "expected Swift Shims at: \(shimsPath.description)")
+  return (stdLibPath, shimsPath, driver.toolchain, driver.hostTriple)
+}
+
+func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath) {
+  let toolchainRootPath: AbsolutePath = try driver.toolchain.getToolPath(.swiftCompiler)
+                                                          .parentDirectory // bin
+                                                          .parentDirectory // toolchain root
+  if driver.targetTriple.isDarwin {
+    let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
+                                           processSet: ProcessSet(),
+                                           fileSystem: localFileSystem,
+                                           env: ProcessEnv.vars)
+    let sdkPath = try executor.checkNonZeroExit(
+      args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
+    let stdLibPath = try AbsolutePath(validating: sdkPath).appending(component: "usr")
+      .appending(component: "lib")
+      .appending(component: "swift")
+    return (stdLibPath, stdLibPath.appending(component: "shims"))
+  } else if driver.targetTriple.isWindows {
+    if let sdkroot = try driver.toolchain.defaultSDKPath(driver.targetTriple) {
+      return (sdkroot.appending(components: "usr", "lib", "swift", "windows"),
+              sdkroot.appending(components: "usr", "lib", "swift", "shims"))
+    }
+    return (toolchainRootPath
+              .appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: driver.targetTriple.osNameUnversioned),
+            toolchainRootPath
+              .appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: "shims"))
+  } else {
+    return (toolchainRootPath.appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: driver.targetTriple.osNameUnversioned),
+            toolchainRootPath.appending(component: "lib")
+              .appending(component: "swift")
+              .appending(component: "shims"))
+  }
+}
+
 /// Test that for the given JSON module dependency graph, valid jobs are generated
 final class ExplicitModuleBuildTests: XCTestCase {
   func testModuleDependencyBuildCommandGeneration() throws {
@@ -1232,60 +1286,6 @@ final class ExplicitModuleBuildTests: XCTestCase {
       // Ensure the dependency has been reported as a framework
       XCTAssertTrue(fooDetails.isFramework)
     }
-  }
-
-  func getStdlibShimsPaths(_ driver: Driver) throws -> (AbsolutePath, AbsolutePath) {
-    let toolchainRootPath: AbsolutePath = try driver.toolchain.getToolPath(.swiftCompiler)
-                                                            .parentDirectory // bin
-                                                            .parentDirectory // toolchain root
-    if driver.targetTriple.isDarwin {
-      let executor = try SwiftDriverExecutor(diagnosticsEngine: DiagnosticsEngine(handlers: [Driver.stderrDiagnosticsHandler]),
-                                             processSet: ProcessSet(),
-                                             fileSystem: localFileSystem,
-                                             env: ProcessEnv.vars)
-      let sdkPath = try executor.checkNonZeroExit(
-        args: "xcrun", "-sdk", "macosx", "--show-sdk-path").spm_chomp()
-      let stdLibPath = try AbsolutePath(validating: sdkPath).appending(component: "usr")
-        .appending(component: "lib")
-        .appending(component: "swift")
-      return (stdLibPath, stdLibPath.appending(component: "shims"))
-    } else if driver.targetTriple.isWindows {
-      if let sdkroot = try driver.toolchain.defaultSDKPath(driver.targetTriple) {
-        return (sdkroot.appending(components: "usr", "lib", "swift", "windows"),
-                sdkroot.appending(components: "usr", "lib", "swift", "shims"))
-      }
-      return (toolchainRootPath
-                .appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: driver.targetTriple.osNameUnversioned),
-              toolchainRootPath
-                .appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: "shims"))
-    } else {
-      return (toolchainRootPath.appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: driver.targetTriple.osNameUnversioned),
-              toolchainRootPath.appending(component: "lib")
-                .appending(component: "swift")
-                .appending(component: "shims"))
-    }
-  }
-
-  private func getDriverArtifactsForScanning() throws -> (stdLibPath: AbsolutePath,
-                                                          shimsPath: AbsolutePath,
-                                                          toolchain: Toolchain,
-                                                          hostTriple: Triple) {
-    // Just instantiating to get at the toolchain path
-    let driver = try Driver(args: ["swiftc", "-explicit-module-build",
-                                   "-module-name", "testDependencyScanning",
-                                   "test.swift"])
-    let (stdLibPath, shimsPath) = try getStdlibShimsPaths(driver)
-    XCTAssertTrue(localFileSystem.exists(stdLibPath),
-                  "expected Swift StdLib at: \(stdLibPath.description)")
-    XCTAssertTrue(localFileSystem.exists(shimsPath),
-                  "expected Swift Shims at: \(shimsPath.description)")
-    return (stdLibPath, shimsPath, driver.toolchain, driver.hostTriple)
   }
 
   /// Test the libSwiftScan dependency scanning (import-prescan).


### PR DESCRIPTION
Do not always hard-code a macOS triple and pass in explicit stdlib paths to the driver invocations