### PR TITLE
Change swift-argument-parser dependency from 'upToNextMinor' to 'from'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -170,7 +170,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
     // dependency version changes here with those projects.
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
upToNextMinor is no longer needed since swift-argument-parser reached 1.0. Unblocks downstream projects from adopting a newer swift-argument-parser.