### PR TITLE
Re-enable testVerboseImmediateMode for macos-arm64.

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5625,9 +5625,6 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testVerboseImmediateMode() throws {
-    #if os(macOS) && arch(arm64)
-      try XCTSkipIf(true, "Temporarily disabled on Apple Silicon (rdar://80558898)")
-    #endif
 
 // There is nothing particularly macOS-specific about this test other than
 // the use of some macOS-specific XCTest functionality to determine the


### PR DESCRIPTION
This test was disabled temporarily in 2021, but the linked radar was closed in 2021 as unreproducible. 

Seems to be passing reliably now on macos-arm64 platform and can be re-enabled.