### PR TITLE
[Driver] Pass -emit-irgen thru to frontend.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2193,7 +2193,10 @@ extension Driver {
       case .emitSibgen:
         compilerOutputType = .raw_sib
 
-      case .emitIrgen, .emitIr:
+      case .emitIrgen:
+        compilerOutputType = .raw_llvmIr
+
+      case .emitIr:
         compilerOutputType = .llvmIR
 
       case .emitBc:

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -75,8 +75,8 @@ extension Driver {
   /// Is this compile job top-level
   func isTopLevelOutput(type: FileType?) -> Bool {
     switch type {
-    case .assembly, .sil, .raw_sil, .llvmIR, .ast, .jsonDependencies, .sib, .raw_sib,
-         .importedModules, .indexData:
+    case .assembly, .sil, .raw_sil, .raw_llvmIr, .llvmIR, .ast, .jsonDependencies, .sib,
+          .raw_sib, .importedModules, .indexData:
       return true
     case .object:
       return (linkerOutputType == nil)
@@ -463,6 +463,8 @@ extension FileType {
       return .emitSibgen
     case .sib:
       return .emitSib
+    case .raw_llvmIr:
+      return .emitIrgen
     case .llvmIR:
       return .emitIr
     case .llvmBitcode:

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -72,6 +72,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// Raw sib file
   case raw_sib
 
+  /// Raw LLVM IR file
+  case raw_llvmIr
+
   /// LLVM IR file
   case llvmIR = "ll"
 
@@ -188,6 +191,9 @@ extension FileType: CustomStringConvertible {
     case .raw_sib:
       return "raw-sib"
 
+    case .raw_llvmIr:
+      return "raw-llvm-ir"
+
     case .llvmIR:
       return "llvm-ir"
 
@@ -285,7 +291,7 @@ extension FileType {
          .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures,
          .jsonSwiftArtifacts, .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline,
          .jsonABIBaseline, .swiftConstValues, .jsonAPIDescriptor,
-         .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
+         .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics, .raw_llvmIr:
       return false
     }
   }
@@ -352,6 +358,8 @@ extension FileType {
       return "raw-sil"
     case .raw_sib:
       return "raw-sib"
+    case .raw_llvmIr:
+      return "raw-llvm-ir"
     case .llvmIR:
       return "llvm-ir"
     case .llvmBitcode:
@@ -412,7 +420,8 @@ extension FileType {
          .moduleTrace, .yamlOptimizationRecord, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface,
          .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo,
          .jsonSwiftArtifacts, .jsonAPIBaseline, .jsonABIBaseline, .swiftConstValues,
-         .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
+         .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics,
+         .raw_llvmIr:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -436,7 +445,8 @@ extension FileType {
          .modDepCache, .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies,
          .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
          .indexUnitOutputPath, .jsonAPIBaseline, .jsonABIBaseline, .swiftConstValues,
-         .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
+         .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics,
+         .raw_llvmIr:
       return false
     }
   }
@@ -446,7 +456,7 @@ extension FileType {
     switch self {
     case .swift, .ast, .indexData, .indexUnitOutputPath, .jsonCompilerFeatures, .jsonTargetInfo:
       return false
-    case .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink, .swiftModule, .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile, .swiftConstValues, .assembly, .raw_sil, .raw_sib, .llvmIR, .llvmBitcode, .diagnostics, .emitModuleDiagnostics, .emitModuleDependencies, .objcHeader, .swiftDeps, .modDepCache, .remap, .importedModules, .tbd, .jsonDependencies, .jsonSwiftArtifacts, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm, .pch, .clangModuleMap, .jsonAPIBaseline, .jsonABIBaseline, .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
+    case .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink, .swiftModule, .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile, .swiftConstValues, .assembly, .raw_sil, .raw_sib, .llvmIR, .llvmBitcode, .diagnostics, .emitModuleDiagnostics, .emitModuleDependencies, .objcHeader, .swiftDeps, .modDepCache, .remap, .importedModules, .tbd, .jsonDependencies, .jsonSwiftArtifacts, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm, .pch, .clangModuleMap, .jsonAPIBaseline, .jsonABIBaseline, .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics, .raw_llvmIr:
       return true
     }
   }
@@ -468,7 +478,7 @@ extension FileType {
          .moduleTrace, .indexData, .yamlOptimizationRecord,
          .bitstreamOptimizationRecord, .pcm, .pch, .jsonDependencies,
          .jsonAPIBaseline, .jsonABIBaseline, .swiftConstValues, .jsonAPIDescriptor,
-         .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics:
+         .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics, .raw_llvmIr:
       return true
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -8166,6 +8166,26 @@ final class SwiftDriverTests: XCTestCase {
     }
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-cache-compile-job", "-explicit-module-build")
   }
+
+  func testEmitLLVMIR() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-irgen", "file.swift"])
+      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(jobs.count, 1)
+
+      XCTAssertTrue(jobs[0].commandLine.contains("-emit-irgen"))
+      XCTAssertTrue(!jobs[0].commandLine.contains("-emit-ir"))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-emit-ir", "file.swift"])
+      let jobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(jobs.count, 1)
+
+      XCTAssertTrue(jobs[0].commandLine.contains("-emit-ir"))
+      XCTAssertTrue(!jobs[0].commandLine.contains("-emit-irgen"))
+    }
+  }
 }
 
 func assertString(


### PR DESCRIPTION
Add a new filetype for this mode option: "Raw LLVM IR". When the mode option is emit-irgen, the new filetype will be the output kind; conversely when determining the mode option to use, if the output kind is the new filetype, the mode option will be emit-irgen.

rdar://135437693
