### PR TITLE
Only make input paths absolute when -working-directory is passed

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -184,7 +184,7 @@ public extension Driver {
 
     if supportInProcessSwiftScanQueries {
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
-      guard let cwd = workingDirectory else {
+      guard let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory else {
         throw DependencyScanningError.dependencyScanFailed("cannot determine working directory")
       }
       var command = try Self.itemizedJobCommand(of: preScanJob,
@@ -260,7 +260,7 @@ public extension Driver {
 
     if supportInProcessSwiftScanQueries {
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
-      guard let cwd = workingDirectory else {
+      guard let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory else {
         throw DependencyScanningError.dependencyScanFailed("cannot determine working directory")
       }
       var command = try Self.itemizedJobCommand(of: scannerJob,
@@ -298,7 +298,7 @@ public extension Driver {
 
     if supportInProcessSwiftScanQueries {
       var scanDiagnostics: [ScannerDiagnosticPayload] = []
-      guard let cwd = workingDirectory else {
+      guard let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory else {
         throw DependencyScanningError.dependencyScanFailed("cannot determine working directory")
       }
       var command = try Self.itemizedJobCommand(of: batchScanningJob,

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -401,7 +401,7 @@ extension Driver {
       if let compilationDir = parsedOptions.getLastArgument(.fileCompilationDir)?.asSingle {
         let compDirPath = try VirtualPath.intern(path: compilationDir)
         try addPathArgument(VirtualPath.lookup(compDirPath), to:&commandLine, remap: jobNeedPathRemap)
-      } else if let cwd = workingDirectory {
+      } else if let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory {
         let compDirPath = VirtualPath.absolute(cwd)
         try addPathArgument(compDirPath, to:&commandLine, remap: jobNeedPathRemap)
       }
@@ -837,7 +837,7 @@ extension Driver {
 
 extension Driver {
   private func getAbsolutePathFromVirtualPath(_ path: VirtualPath) -> AbsolutePath? {
-    guard let cwd = workingDirectory else {
+    guard let cwd = workingDirectory ?? fileSystem.currentWorkingDirectory else {
       return nil
     }
     return path.resolvedRelativePath(base: cwd).absolutePath

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -186,7 +186,7 @@ extension Driver {
                                                              fileSystem: FileSystem,
                                                              workingDirectory: AbsolutePath?,
                                                              invocationCommand: [String]) throws -> FrontendTargetInfo {
-    let cwd = try workingDirectory ?? fileSystem.tempDirectory
+    let cwd = try workingDirectory ?? fileSystem.currentWorkingDirectory ?? fileSystem.tempDirectory
     let compilerExecutablePath = try toolchain.resolvedTool(.swiftCompiler).path
     let targetInfoData =
     try libSwiftScanInstance.queryTargetInfoJSON(workingDirectory: cwd,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -45,12 +45,15 @@ private var testInputsPath: AbsolutePath {
   }
 }
 
-func toPath(_ path: String, base: AbsolutePath = localFileSystem.currentWorkingDirectory!) throws -> VirtualPath {
-  return try VirtualPath(path: path).resolvedRelativePath(base: base)
+func toPath(_ path: String, isRelative: Bool = true) throws -> VirtualPath {
+  if isRelative {
+    return VirtualPath.relative(try .init(validating: path))
+  }
+  return try VirtualPath(path: path).resolvedRelativePath(base: localFileSystem.currentWorkingDirectory!)
 }
 
-func toPathOption(_ path: String, base:  AbsolutePath = localFileSystem.currentWorkingDirectory!) throws -> Job.ArgTemplate {
-  return .path(try toPath(path, base: base))
+func toPathOption(_ path: String, isRelative: Bool = true) throws -> Job.ArgTemplate {
+  return .path(try toPath(path, isRelative: isRelative))
 }
 
 final class SwiftDriverTests: XCTestCase {
@@ -351,7 +354,7 @@ final class SwiftDriverTests: XCTestCase {
       ])
       XCTAssertEqual(driver.recordedInputModificationDates, [
         .init(file: VirtualPath.absolute(main).intern(), type: .swift) : mainMDate,
-        .init(file: VirtualPath.absolute(util).intern(), type: .swift) : utilMDate,
+        .init(file: VirtualPath.relative(utilRelative).intern(), type: .swift) : utilMDate,
       ])
     }
   }
@@ -1295,12 +1298,11 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
-      XCTAssertTrue(plannedJobs[0].primaryInputs.map{ $0.file.description }.elementsEqual([rebase("foo.swift"),
-                                                                                           rebase("bar.swift")]))
+      XCTAssertTrue(plannedJobs[0].primaryInputs.map{ $0.file.description }.elementsEqual(["foo.swift", "bar.swift"]))
       XCTAssertTrue(plannedJobs[0].commandLine.contains("-emit-const-values-path"))
       XCTAssertEqual(plannedJobs[0].outputs.filter({ $0.type == .swiftConstValues }).count, 2)
       XCTAssertEqual(plannedJobs[1].kind, .compile)
-      XCTAssertTrue(plannedJobs[1].primaryInputs.map{ $0.file.description }.elementsEqual([rebase("baz.swift")]))
+      XCTAssertTrue(plannedJobs[1].primaryInputs.map{ $0.file.description }.elementsEqual(["baz.swift"]))
       XCTAssertTrue(plannedJobs[1].commandLine.contains("-emit-const-values-path"))
       XCTAssertEqual(plannedJobs[1].outputs.filter({ $0.type == .swiftConstValues }).count, 1)
       XCTAssertEqual(plannedJobs[2].kind, .link)
@@ -1331,13 +1333,12 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(plannedJobs.count, 3)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
-      XCTAssertTrue(plannedJobs[0].primaryInputs.map{ $0.file.description }.elementsEqual([rebase("foo.swift"),
-                                                                                           rebase("bar.swift")]))
+      XCTAssertTrue(plannedJobs[0].primaryInputs.map{ $0.file.description }.elementsEqual(["foo.swift", "bar.swift"]))
       XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(try .init(validating: "/tmp/foo.build/foo.swiftconstvalues")))]))
       XCTAssertTrue(plannedJobs[0].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(try .init(validating: "/tmp/foo.build/bar.swiftconstvalues")))]))
       XCTAssertEqual(plannedJobs[0].outputs.filter({ $0.type == .swiftConstValues }).count, 2)
       XCTAssertEqual(plannedJobs[1].kind, .compile)
-      XCTAssertTrue(plannedJobs[1].primaryInputs.map{ $0.file.description }.elementsEqual([rebase("baz.swift")]))
+      XCTAssertTrue(plannedJobs[1].primaryInputs.map{ $0.file.description }.elementsEqual(["baz.swift"]))
       XCTAssertTrue(plannedJobs[1].commandLine.contains("-emit-const-values-path"))
       XCTAssertEqual(plannedJobs[1].outputs.filter({ $0.type == .swiftConstValues }).count, 1)
       XCTAssertTrue(plannedJobs[1].commandLine.contains(subsequence: [.flag("-emit-const-values-path"), .path(.absolute(try .init(validating: "/tmp/foo.build/baz.swiftconstvalues")))]))
@@ -3039,10 +3040,10 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(emitModuleJob.outputs[0].file, try toPath("Test.swiftmodule"))
     XCTAssertEqual(emitModuleJob.outputs[1].file, try toPath("Test.swiftdoc"))
     XCTAssertEqual(emitModuleJob.outputs[2].file, try toPath("Test.swiftsourceinfo"))
-    XCTAssertEqual(emitModuleJob.outputs[3].file, try toPath("Test.swiftinterface"))
+    XCTAssertEqual(emitModuleJob.outputs[3].file, try VirtualPath(path: "./Test.swiftinterface"))
     XCTAssertEqual(emitModuleJob.outputs[4].file, try toPath("Test.private.swiftinterface"))
     XCTAssertEqual(emitModuleJob.outputs[5].file, try toPath("Test-Swift.h"))
-    XCTAssertEqual(emitModuleJob.outputs[6].file, try toPath("Test.tbd"))
+    XCTAssertEqual(emitModuleJob.outputs[6].file, try VirtualPath(path: "./Test.tbd"))
     if driver1.targetTriple.isDarwin {
         XCTAssertEqual(emitModuleJob.outputs[7].file, try toPath("Test.abi.json"))
     }
@@ -5188,7 +5189,7 @@ final class SwiftDriverTests: XCTestCase {
     // Reset the temporary store to ensure predictable results.
     VirtualPath.resetTemporaryFileStore()
     var driver = try Driver(args: [
-      "swiftc", "-emit-executable", "test.swift", "-emit-module", "-avoid-emit-module-source-info", "-experimental-emit-module-separately"
+      "swiftc", "-emit-executable", "test.swift", "-emit-module", "-avoid-emit-module-source-info", "-experimental-emit-module-separately", "-working-directory", localFileSystem.currentWorkingDirectory!.description
     ])
     let plannedJobs = try driver.planBuild()
 
@@ -7234,6 +7235,83 @@ final class SwiftDriverTests: XCTestCase {
       })
     }
   }
+  
+  func testRelativeInputs() throws {
+    do {
+      // Inputs with relative paths with no -working-directory flag should remain relative
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "arm64-apple-ios13.1",
+                                     "foo.swift"])
+      let plannedJobs = try driver.planBuild()
+      let compileJob = plannedJobs[0]
+      XCTAssertEqual(compileJob.kind, .compile)
+      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-primary-file", try toPathOption("foo.swift", isRelative: true)]))
+    }
+
+    do {
+      // Inputs with relative paths with -working-directory flag should prefix all inputs
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "arm64-apple-ios13.1",
+                                     "foo.swift",
+                                     "-working-directory", "/foo/bar"])
+      let plannedJobs = try driver.planBuild()
+      let compileJob = plannedJobs[0]
+      XCTAssertEqual(compileJob.kind, .compile)
+      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-primary-file", try toPathOption("/foo/bar/foo.swift", isRelative: false)]))
+    }
+    
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+      {
+        "": {
+          "diagnostics": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia",
+          "emit-module-diagnostics": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia"
+        },
+        "foo.swift": {
+          "object": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o"
+        }
+      }
+      """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+      
+      // Inputs with relative paths should be found in output file maps
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "arm64-apple-ios13.1",
+                                     "foo.swift",
+                                     "-output-file-map", fileMapFile.path.description])
+      let plannedJobs = try driver.planBuild()
+      let compileJob = plannedJobs[0]
+      XCTAssertEqual(compileJob.kind, .compile)
+      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-o", try toPathOption("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o", isRelative: false)]))
+    }
+    
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+      {
+        "": {
+          "diagnostics": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia",
+          "emit-module-diagnostics": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia"
+        },
+        "/some/workingdir/foo.swift": {
+          "object": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o"
+        }
+      }
+      """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+      
+      // Inputs with relative paths and working-dir should use absolute paths in output file maps
+      var driver = try Driver(args: ["swiftc",
+                                     "-target", "arm64-apple-ios13.1",
+                                     "foo.swift",
+                                     "-working-directory", "/some/workingdir",
+                                     "-output-file-map", fileMapFile.path.description])
+      let plannedJobs = try driver.planBuild()
+      let compileJob = plannedJobs[0]
+      XCTAssertEqual(compileJob.kind, .compile)
+      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-o", try toPathOption("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o", isRelative: false)]))
+    }
+    
+  }
 
   func testRelativeResourceDir() throws {
     do {
@@ -7274,7 +7352,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(compileJob.kind, .compile)
       let linkJob = plannedJobs[1]
       XCTAssertEqual(linkJob.kind, .link)
-      XCTAssertTrue(linkJob.commandLine.contains(try toPathOption(sdkRoot.pathString + "/usr/lib/swift/linux/x86_64/swiftrt.o")))
+      XCTAssertTrue(linkJob.commandLine.contains(try toPathOption(sdkRoot.pathString + "/usr/lib/swift/linux/x86_64/swiftrt.o", isRelative: false)))
     }
   }
 


### PR DESCRIPTION
This is a partial revert of https://github.com/swiftlang/swift-driver/commit/a9f35bc15f68d4ae0cd3949afa6c78e1a3df8f80

When remotely building and sharing Swift artifacts it is important to maintain
relative paths to avoid serializing any paths that will not be valid on different
machines. Change the logic back to the previous model, and the one used
in the old swift driver, where paths are made absolute only when a 
`-working-directory` flag is passed.