### PR TITLE
Unlock `-profile-generate` for WebAssembly targets

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -160,8 +160,11 @@ extension WebAssemblyToolchain {
         throw Error.sanitizersUnsupportedForTarget(targetTriple.triple)
       }
 
-      guard !parsedOptions.hasArgument(.profileGenerate) else {
-        throw Error.profilingUnsupportedForTarget(targetTriple.triple)
+      if parsedOptions.hasArgument(.profileGenerate) {
+        let libProfile = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+          .appending(components: "clang", "lib", targetTriple.osName,
+                                 "libclang_rt.profile-\(targetTriple.archName).a")
+        commandLine.appendPath(libProfile)
       }
 
       if let lto = lto {


### PR DESCRIPTION
We added support for `-profile-generate` in the latest LLVM (https://github.com/swiftlang/llvm-project/pull/9418), but it is explicitly banned for WebAssembly targets now. Unlock the feature by adding the necessary runtime library to the link command line as well as other platforms.