### PR TITLE
Only pass `--rsp-quoting=windows` to `clang`

### DIFF
--- a/Sources/SwiftDriver/Jobs/LinkJob.swift
+++ b/Sources/SwiftDriver/Jobs/LinkJob.swift
@@ -49,15 +49,6 @@ extension Driver {
   mutating func linkJob(inputs: [TypedVirtualPath]) throws -> Job {
     var commandLine: [Job.ArgTemplate] = []
 
-    #if os(Windows)
-    // We invoke clang as `clang.exe`, which expects a POSIX-style response file by default (`clang-cl.exe` expects
-    // Windows-style response files).
-    // The driver is outputting Windows-style response files because swift-frontend expects Windows-style response
-    // files.
-    // Force `clang.exe` into parsing Windows-style response files.
-    commandLine.appendFlag("--rsp-quoting=windows")
-    #endif
-
     // Compute the final output file
     let outputFile: VirtualPath
     if let output = parsedOptions.getLastArgument(.o) {

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -94,6 +94,13 @@ extension WindowsToolchain {
     let clangTool: Tool = cxxCompatEnabled ? .clangxx : .clang
     var clang = try getToolPath(clangTool)
 
+    // We invoke clang as `clang.exe`, which expects a POSIX-style response file by default (`clang-cl.exe` expects
+    // Windows-style response files).
+    // The driver is outputting Windows-style response files because swift-frontend expects Windows-style response
+    // files.
+    // Force `clang.exe` into parsing Windows-style response files.
+    commandLine.appendFlag("--rsp-quoting=windows")
+
     let targetTriple = targetInfo.target.triple
     if !targetTriple.triple.isEmpty {
       commandLine.appendFlag("-target")


### PR DESCRIPTION
We were unconditionally passing `--rsp-quoting` to the linker on Windows. As far as I can tell, there are three different linkers we invoke on Windows:
- `clang.exe`: This is what this fix is intended to cover
- `lld-link.exe`: Defaults to Windows quoting style in response files and `--rsp-quoting=windows` is a no-op.
- `link.exe`: Does not accept `--rsp-quoting=windows`

Move `--rsp-quoting=windows` to the point where we decide to use `clang.exe` as the linker on Windows and only pass it to `clang.exe`.