### PR TITLE
[Darwin] Add external plugin paths into platform specified by PLATFORM_DIR

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -456,6 +456,17 @@ public final class DarwinToolchain: Toolchain {
     }
 
     if driver.isFrontendArgSupported(.externalPluginPath) {
+      // If the PLATFORM_DIR environment variable is set, also add plugin
+      // paths into it. Since this is a user override, it comes beore the
+      // default platform path that's based on the SDK.
+      if let platformDir = env["PLATFORM_DIR"],
+         let platformPath = try? VirtualPath(path: platformDir) {
+        addPluginPaths(
+          forPlatform: platformPath,
+          commandLine: &commandLine
+        )
+      }
+
       // Determine the platform path based on the SDK path.
       addPluginPaths(
         forPlatform: VirtualPath.lookup(sdkPath)
@@ -464,16 +475,6 @@ public final class DarwinToolchain: Toolchain {
           .parentDirectory,
         commandLine: &commandLine
       )
-
-      // If the PLATFORM_DIR environment variable is set, also add plugin
-      // paths into it.
-      if let platformDir = env["PLATFORM_DIR"],
-         let platformPath = try? VirtualPath(path: platformDir) {
-        addPluginPaths(
-          forPlatform: platformPath,
-          commandLine: &commandLine
-        )
-      }
     }
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7805,7 +7805,7 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertNotNil(envPlatformPluginPathIndex)
 
     if let platformPluginPathIndex, let envPlatformPluginPathIndex {
-      XCTAssertLessThan(platformPluginPathIndex, envPlatformPluginPathIndex)
+      XCTAssertLessThan(envPlatformPluginPathIndex, platformPluginPathIndex)
     }
 
     let toolchainPluginPathIndex = job.commandLine.firstIndex(of: .path(.absolute(try driver.toolchain.executableDir.parentDirectory.appending(components: "lib", "swift", "host", "plugins"))))


### PR DESCRIPTION
The driver currently has logic to infer the location of the platform based on the conventional layout of SDKs within platforms. However, that doesn't work well when SDKs have been built up in other places.

Introduce support for a second convention, that the PLATFORM_DIR environment variable can specify the path to the platform. When present, also add external plugin paths pointing into that platform.

Fixes rdar://138370421.