### PR TITLE
[Explicit Module Builds] Always filter out up-to-date module dependencies from execution

### DIFF
--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -30,6 +30,7 @@ extension Option {
   public static let allowNonResilientAccess: Option = Option("-allow-non-resilient-access", .flag, attributes: [.frontend], helpText: "Ensures all contents are generated besides exportable decls in the binary module, so non-resilient access can be allowed")
   public static let allowableClient: Option = Option("-allowable-client", .separate, attributes: [.frontend, .moduleInterface], metaVar: "<vers>", helpText: "Module names that are allowed to import this module")
   public static let alwaysCompileOutputFiles: Option = Option("-always-compile-output-files", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Always compile output files even it might not change the results")
+  public static let alwaysRebuildModuleDependencies: Option = Option("-always-rebuild-module-dependencies", .flag, attributes: [.helpHidden], helpText: "Always rebuild module dependencies")
   public static let analyzeRequestEvaluator: Option = Option("-analyze-request-evaluator", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Print out request evaluator cache statistics at the end of the compilation job")
   public static let analyzeRequirementMachine: Option = Option("-analyze-requirement-machine", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Print out requirement machine statistics at the end of the compilation job")
   public static let apiDiffDataDir: Option = Option("-api-diff-data-dir", .separate, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild, .argumentIsPath], metaVar: "<path>", helpText: "Load platform and version specific API migration data files from <path>. Ignored if -api-diff-data-file is specified.")
@@ -935,6 +936,7 @@ extension Option {
       Option.allowNonResilientAccess,
       Option.allowableClient,
       Option.alwaysCompileOutputFiles,
+      Option.alwaysRebuildModuleDependencies,
       Option.analyzeRequestEvaluator,
       Option.analyzeRequirementMachine,
       Option.apiDiffDataDir,


### PR DESCRIPTION
With an escape hatch of `-always-rebuild-module-dependencies` (https://github.com/swiftlang/swift/pull/77717). This change makes it so the driver is always going to produce a build plan which contains only explicit module pre-compile tasks for modules which are not already up-to-date with respect to all of their inputs.

This means that the driver will skip up-to-date module tasks even when `-incremental` is not specified. This is more in line with prior behavior when using Implicit Module builds and results in a better user experience when compiling code with `swiftc` on the command-line. For example, consequtive invocations of `swiftc test.swift -o test.out` should not have to re-build module dependencies of `test.swift` each time.

Swift's `-incremental` is a heavy-weight set of machinery for selective re-compilation of a target in single-file/batch mode, whereas checking which module dependencies are up-to-date is a much simpler mechanism which we have no reason not to run on each compile. 

This change takes the existing logic that ran during a full Incremental build first wave to determine which dependencies need to be re-built and moves it to a common non-incremental code-path. 