### PR TITLE
Exclude `.autolink` files from static linking on WebAssembly

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -198,7 +198,7 @@ extension WebAssemblyToolchain {
       commandLine.appendFlag("crs")
       commandLine.appendPath(outputFile)
 
-      commandLine.append(contentsOf: inputs.map { .path($0.file) })
+      commandLine.append(contentsOf: inputs.lazy.filter { $0.type != .autolink }.map { .path($0.file) })
       return try resolvedTool(.staticLinker(lto))
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2371,6 +2371,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(cmd.contains(.flag("-dylib")))
       XCTAssertFalse(cmd.contains(.flag("-static")))
       XCTAssertFalse(cmd.contains(.flag("-shared")))
+      XCTAssertFalse(commandContainsTemporaryPath(cmd, "Test.autolink"))
     }
 
     do {


### PR DESCRIPTION
The `.autolink` files were being included in static archives and they were silently ignored by wasm-ld linker but they started emitting warnings for archive members that are neither object files nor bitcode files[^1]. This change filters out `.autolink` files from the list of inputs to the static linker job to avoid the warnings.

[^1]: https://github.com/llvm/llvm-project/commit/bcc9b9d80c61ea6521215e9826281041a3f73b05