### PR TITLE
[cxx-interop] Handle different interop compat versions

### DIFF
--- a/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/DarwinToolchain+LinkerSupport.swift
@@ -243,7 +243,7 @@ extension DarwinToolchain {
     // On Darwin, we only support libc++.
     var cxxCompatEnabled = parsedOptions.hasArgument(.enableExperimentalCxxInterop)
     if let cxxInteropMode = parsedOptions.getLastArgument(.cxxInteroperabilityMode) {
-      if cxxInteropMode.asSingle == "swift-5.9" {
+      if cxxInteropMode.asSingle != "off" {
         cxxCompatEnabled = true
       }
     }

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -78,7 +78,7 @@ extension GenericUnixToolchain {
       // just using `clang` and avoid a dependency on the C++ runtime.
       var cxxCompatEnabled = parsedOptions.hasArgument(.enableExperimentalCxxInterop)
       if let cxxInteropMode = parsedOptions.getLastArgument(.cxxInteroperabilityMode) {
-        if cxxInteropMode.asSingle == "swift-5.9" {
+        if cxxInteropMode.asSingle != "off" {
           cxxCompatEnabled = true
         }
       }

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -87,7 +87,7 @@ extension WindowsToolchain {
 
     var cxxCompatEnabled = parsedOptions.hasArgument(.enableExperimentalCxxInterop)
     if let cxxInteropMode = parsedOptions.getLastArgument(.cxxInteroperabilityMode) {
-      if cxxInteropMode.asSingle == "swift-5.9" {
+      if cxxInteropMode.asSingle != "off" {
         cxxCompatEnabled = true
       }
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7064,7 +7064,7 @@ final class SwiftDriverTests: XCTestCase {
     env["SWIFT_DRIVER_CLANGXX_EXEC"] = swiftClangxx.pathString
 
     var driver = try Driver(
-      args: ["swiftc", "-cxx-interoperability-mode=swift-5.9", "-emit-library",
+      args: ["swiftc", "-cxx-interoperability-mode=swift-6", "-emit-library",
              "foo.swift", "bar.o", "-o", "foo.l"],
       env: env)
 
@@ -7707,7 +7707,7 @@ final class SwiftDriverTests: XCTestCase {
 #else
       VirtualPath.resetTemporaryFileStore()
       var driver = try Driver(args: [
-        "swiftc", "-cxx-interoperability-mode=swift-5.9", "-emit-library", "-o", "library.dll", "library.obj"
+        "swiftc", "-cxx-interoperability-mode=upcoming-swift", "-emit-library", "-o", "library.dll", "library.obj"
       ])
       let jobs = try driver.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(jobs.count, 1)


### PR DESCRIPTION
Apart from `swift-5.9`, the `-cxx-interoperability-flag` compiler flag might take other values, such as `swift-6`, `default`, or `upcoming-swift`.

This teaches Swift Driver to properly handle any of those values.