### PR TITLE
SwiftDriver: adjust handling of `-resource-dir` parameter

### DIFF
--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -173,7 +173,10 @@ extension WindowsToolchain {
       // finally falling back to the target information.
       let rsrc: VirtualPath
       if let resourceDir = parsedOptions.getLastArgument(.resourceDir) {
-        rsrc = try VirtualPath(path: resourceDir.asSingle)
+        rsrc = try VirtualPath(path: AbsolutePath(validating: resourceDir.asSingle)
+                                        .appending(components: targetTriple.platformName() ?? "",
+                                                   architecture(for: targetTriple))
+                                        .pathString)
       } else if let sdk = parsedOptions.getLastArgument(.sdk)?.asSingle ?? env["SDKROOT"], !sdk.isEmpty {
         rsrc = try VirtualPath(path: AbsolutePath(validating: sdk)
                                         .appending(components: "usr", "lib", "swift",
@@ -182,6 +185,8 @@ extension WindowsToolchain {
                                         .pathString)
       } else {
         rsrc = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+                          .appending(components: targetTriple.platformName() ?? "",
+                                     architecture(for: targetTriple))
       }
       commandLine.appendPath(rsrc.appending(component: "swiftrt.obj"))
     }


### PR DESCRIPTION
When computing the resource directory for the Swift registrar, we need to add a couple of components that we had missed. Correct the path computation so that we can find the object file properly. This was detected while running the test suite with the early swift driver on Windows where `-resource-dir` is explicitly passed.