### PR TITLE
[6.0] Disable in-process target-info and supported-features queries using `libSwiftScan`

### DIFF
--- a/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitSupportedFeaturesJob.swift
@@ -64,14 +64,16 @@ extension Driver {
                                            fileSystem: FileSystem,
                                            executor: DriverExecutor)
   throws -> Set<String> {
-    do {
-      if let supportedArgs =
-          try querySupportedCompilerArgsInProcess(of: toolchain, fileSystem: fileSystem) {
-        return supportedArgs
-      }
-    } catch {
-      diagnosticsEngine.emit(.remark_inprocess_supported_features_query_failed(error.localizedDescription))
-    }
+    // Disable in-process supported features query due to a race condition in the compiler's current
+    // build system where libSwiftScan may not be ready when building the Swift standard library.
+//    do {
+//      if let supportedArgs =
+//          try querySupportedCompilerArgsInProcess(of: toolchain, fileSystem: fileSystem) {
+//        return supportedArgs
+//      }
+//    } catch {
+//      diagnosticsEngine.emit(.remark_inprocess_supported_features_query_failed(error.localizedDescription))
+//    }
 
     // Fallback: Invoke `swift-frontend -emit-supported-features` and decode the output
     let frontendOverride = try FrontendOverride(&parsedOptions, diagnosticsEngine)

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -248,16 +248,18 @@ extension Driver {
                                               using: executor.resolver)
     Self.sanitizeCommandForLibScanInvocation(&command)
 
-    do {
-      if let targetInfo =
-          try Self.queryTargetInfoInProcess(of: toolchain, fileSystem: fileSystem,
-                                            workingDirectory: workingDirectory,
-                                            invocationCommand: command) {
-        return targetInfo
-      }
-    } catch {
-      diagnosticsEngine.emit(.remark_inprocess_target_info_query_failed(error.localizedDescription))
-    }
+    // Disable in-process target query due to a race condition in the compiler's current
+    // build system where libSwiftScan may not be ready when building the Swift standard library.
+//    do {
+//      if let targetInfo =
+//          try Self.queryTargetInfoInProcess(of: toolchain, fileSystem: fileSystem,
+//                                            workingDirectory: workingDirectory,
+//                                            invocationCommand: command) {
+//        return targetInfo
+//      }
+//    } catch {
+//      diagnosticsEngine.emit(.remark_inprocess_target_info_query_failed(error.localizedDescription))
+//    }
 
     // Fallback: Invoke `swift-frontend -print-target-info` and decode the output
     return try executor.execute(


### PR DESCRIPTION
When building the compiler toolchain, there is currently a race condition which makes it so that the 'libSwiftScan.dylib' is not ready by the time the driver is used to begin compilation of the Swift standard library. For now, disable in-process queries altogether.

On 'main', this is resolved with https://github.com/swiftlang/swift/pull/77606, which seems to be a challenge to backport to 6.0.