### PR TITLE
Fix some of `ProcessEnv.vars` and `AbsolutePath` warnings

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -73,7 +73,7 @@ do {
 
   // Fallback to legacy driver if forced to
   if CommandLine.arguments.contains(Option.disallowForwardingDriver.spelling) ||
-     ProcessEnv.vars["SWIFT_USE_OLD_DRIVER"] != nil {
+     ProcessEnv.block["SWIFT_USE_OLD_DRIVER"] != nil {
     // If CommandLine.argument[0] is not an absolute path, we would form a path
     // relative to the current directory rather than relative to the actual
     // location of the binary. Use the Founation `NSProcessInfo` type to compute
@@ -89,7 +89,7 @@ do {
                   .appendingPathExtension(executable.pathExtension)
     let path: String = legacyExecutablePath.withUnsafeFileSystemRepresentation { String(cString: $0!) }
 
-    if localFileSystem.exists(AbsolutePath(path)) {
+    if try localFileSystem.exists(AbsolutePath(validating: path)) {
       let legacyDriverCommand = [path] + CommandLine.arguments[1...]
       try exec(path: path, args: legacyDriverCommand)
     } else {
@@ -97,7 +97,7 @@ do {
     }
   }
 
-  if ProcessEnv.vars["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {
+  if ProcessEnv.block["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {
     CommandLine.arguments.append("-explicit-module-build")
   }
 

--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -93,7 +93,7 @@ struct SwiftHelp: ParsableCommand {
   }
 
   func printIntro() {
-    let is256Color = ProcessEnv.vars["TERM"] == "xterm-256color"
+    let is256Color = ProcessEnv.block["TERM"] == "xterm-256color"
     let orangeRed = is256Color ? "\u{001b}[1;38;5;196m" : ""
     let plain = is256Color ? "\u{001b}[0m" : ""
     let plainBold = is256Color ? "\u{001b}[1m" : ""


### PR DESCRIPTION
Fixed some of these warnings:

```
warning: 'vars' is deprecated: Use `block` instead
```
```
- warning: 'init(_:)' is deprecated: use throwing `init(validating:)` variant instead
```

Fixing the former also improves compatibility with Windows env vars handling.