### PR TITLE
Tests: introduce and partially adopt a command line test helper

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -1573,8 +1573,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       }
 
       let scannerJob = try driver.dependencyScanningJob()
-      XCTAssertTrue(scannerJob.commandLine.contains(subsequence: [.flag("-clang-scanner-module-cache-path"),
-                                                                  .path(.absolute(scannerCachePath))]))
+      XCTAssertCommandLineContains(scannerJob.commandLine, .flag("-clang-scanner-module-cache-path"), .path(.absolute(scannerCachePath)))
     }
   }
 

--- a/Tests/SwiftDriverTests/Helpers/XCTestExtensions.swift
+++ b/Tests/SwiftDriverTests/Helpers/XCTestExtensions.swift
@@ -1,0 +1,32 @@
+//===-------- AssertDiagnostics.swift - Diagnostic Test Assertions --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftDriver
+
+internal func XCTAssertCommandLineContains(_ commandline: [Job.ArgTemplate],
+                                           _ subsequence: Job.ArgTemplate...,
+                                           file: StaticString = #file,
+                                           line: UInt = #line) {
+  if !commandline.contains(subsequence: subsequence) {
+    XCTFail("\(commandline) does not contain \(subsequence)", file: file, line: line)
+  }
+}
+
+internal func XCTAssertJobInvocationMatches(_ job: Job,
+                                            _ subsequence: Job.ArgTemplate...,
+                                            file: StaticString = #file,
+                                            line: UInt = #line) {
+  if !job.commandLine.contains(subsequence: subsequence) {
+    XCTFail("\(job.commandLine) does not contain \(subsequence)", file: file, line: line)
+  }
+}


### PR DESCRIPTION
Introduce a `XCTAssertCommandLineContains` and
`XCTAssertJobInvocationMatches` to validate the invocation of the tools. This helper checks that the command line matches the template and in the case of a failure will print both the actual command line template and the expectation so that it is easier to diagnose the failures.

Take the opportunity to clean up some of the job type checks, converting them from `XCTAssertTrue` to `XCTAssertEquals` to ensure that the values are printed.

Perform a partial pass to adopt this new helper in a large set of the SwiftDriverTests. This is a mostly mechanical change, though there are a few places where the tests are actually changed semantically slightly. Those changes are limited to a stronger assertion about the ordering of arguments which was not previously present. These are options where file paths are specified as an argument to an option.