### PR TITLE
Tests: remove some debugging code

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -203,7 +203,7 @@ final class CachingBuildTests: XCTestCase {
     try super.setUpWithError()
 
     // If the toolchain doesn't support caching, skip directly.
-    let driver = try Driver(args: ["swiftc", "-v"])
+    let driver = try Driver(args: ["swiftc"])
 #if os(Windows)
     throw XCTSkip("caching not supported on windows")
 #else
@@ -240,7 +240,7 @@ final class CachingBuildTests: XCTestCase {
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-I", stdlibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
-                                     "-explicit-module-build", "-v",
+                                     "-explicit-module-build",
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
@@ -427,7 +427,7 @@ final class CachingBuildTests: XCTestCase {
                                      "-module-name", "Test",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-				     "-I", stdlibPath.nativePathString(escaped: true),
+                                     "-I", stdlibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
                                      "-emit-module-path", modulePath.nativePathString(escaped: true),
                                      "-emit-module-interface-path", swiftInterfacePath.nativePathString(escaped: true),
@@ -435,8 +435,8 @@ final class CachingBuildTests: XCTestCase {
                                      "-explicit-module-build", "-experimental-emit-module-separately", "-Rcache-compile-job",
                                      "-enable-library-evolution", "-O",
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
-				     "-Xfrontend", "-disable-implicit-concurrency-module-import",
-				     "-Xfrontend", "-disable-implicit-string-processing-module-import",
+                                     "-Xfrontend", "-disable-implicit-concurrency-module-import",
+                                     "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
@@ -624,7 +624,7 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-explicit-module-build", "-v", "-Rcache-compile-job",
+                                     "-explicit-module-build", "-Rcache-compile-job",
                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
@@ -893,7 +893,7 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "/tmp/Foo.o", "-v", "-g",
+                                     "/tmp/Foo.o", "-g",
                                      "-explicit-module-build",
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
@@ -960,7 +960,7 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "-explicit-module-build", "-v", "-Rcache-compile-job", "-incremental",
+                                     "-explicit-module-build", "-Rcache-compile-job", "-incremental",
                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-import-objc-header", bridgingHeaderpath.nativePathString(escaped: true),
@@ -1000,7 +1000,7 @@ final class CachingBuildTests: XCTestCase {
   func testCASManagement() throws {
     try withTemporaryDirectory { path in
       let casPath = path.appending(component: "cas")
-      let driver = try Driver(args: ["swiftc", "-v"])
+      let driver = try Driver(args: ["swiftc"])
       let scanLibPath = try XCTUnwrap(driver.getSwiftScanLibPath())
       try dependencyOracle.verifyOrCreateScannerInstance(swiftScanLibPath: scanLibPath)
       let cas = try dependencyOracle.getOrCreateCAS(pluginPath: nil, onDiskPath: casPath, pluginOptions: [])

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3337,7 +3337,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
-      print(plannedJobs[0].commandLine.joinedUnresolvedArguments)
+
       let outFileMap = try XCTUnwrap(plannedJobs[0].commandLine.supplementaryOutputFilemap)
       XCTAssertEqual(outFileMap.entries.values.first?.keys.first, fileType)
     }
@@ -4463,7 +4463,6 @@ final class SwiftDriverTests: XCTestCase {
       }
       var driver = try Driver(args: args)
       let plannedJobs = try driver.planBuild()
-      print(plannedJobs[1].commandLine)
 
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
@@ -4485,7 +4484,6 @@ final class SwiftDriverTests: XCTestCase {
       // don't use '-lld-allow-duplicate-weak'
       var driver = try Driver(args: ["swiftc", "-profile-generate", "-use-ld=link", "-target", "x86_64-unknown-windows-msvc", "test.swift"])
       let plannedJobs = try driver.planBuild()
-      print(plannedJobs[1].commandLine)
 
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
@@ -4505,7 +4503,6 @@ final class SwiftDriverTests: XCTestCase {
       // If we're not building for profiling, don't add '-lld-allow-duplicate-weak'.
       var driver = try Driver(args: ["swiftc", "-use-ld=lld", "-target", "x86_64-unknown-windows-msvc", "test.swift"])
       let plannedJobs = try driver.planBuild()
-      print(plannedJobs[1].commandLine)
 
       XCTAssertEqual(plannedJobs.count, 2)
       XCTAssertEqual(plannedJobs[0].kind, .compile)


### PR DESCRIPTION
Remove a number of cases where we would print the command line or using `-v` on commands which are being executed which results in a significant amount of output in the test run.