### PR TITLE
Tests: various changes to clean up the swift-driver test suite (NFC)

### DIFF
--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -254,12 +254,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let jsonDepsPathIndex = job.commandLine.firstIndex(of: .flag("-explicit-swift-module-map-file"))
       let jsonDepsPathArg = job.commandLine[jsonDepsPathIndex! + 1]
       guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
-        XCTFail("No JSON dependency file path found.")
-        return
+        return XCTFail("No JSON dependency file path found.")
       }
       guard case let .temporaryWithKnownContents(_, contents) = jsonDepsPath else {
-        XCTFail("Unexpected path type")
-        return
+        return XCTFail("Unexpected path type")
       }
       let dependencyInfoList = try JSONDecoder().decode(Array<SwiftModuleArtifactInfo>.self,
                                                     from: contents)
@@ -367,12 +365,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let jsonDepsPathIndex = compileJob.commandLine.firstIndex(of: explicitDepsFlag)
       let jsonDepsPathArg = compileJob.commandLine[jsonDepsPathIndex! + 1]
       guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
-        XCTFail("No JSON dependency file path found.")
-        return
+        return XCTFail("No JSON dependency file path found.")
       }
       guard case let .temporaryWithKnownContents(_, contents) = jsonDepsPath else {
-        XCTFail("Unexpected path type")
-        return
+        return XCTFail("Unexpected path type")
       }
       let jsonDepsDecoded = try JSONDecoder().decode(Array<ModuleDependencyArtifactInfo>.self, from: contents)
 

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -562,42 +562,33 @@ final class ExplicitModuleBuildTests: XCTestCase {
           if relativeOutputPathFileName.starts(with: "A-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("A"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "B-") {
+          } else if relativeOutputPathFileName.starts(with: "B-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("B"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "C-") {
+          } else if relativeOutputPathFileName.starts(with: "C-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("C"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "D-") {
+          } else if relativeOutputPathFileName.starts(with: "D-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("D"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "G-") {
+          } else if relativeOutputPathFileName.starts(with: "G-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("G"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "F-") {
+          } else if relativeOutputPathFileName.starts(with: "F-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("F"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
+          } else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
+          } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if hostTriple.isMacOSX,
+          } else if hostTriple.isMacOSX,
              hostTriple.version(for: .macOS) < Triple.Version(11, 0, 0),
              relativeOutputPathFileName.starts(with: "X-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("X"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else {
+          } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
         } else {
@@ -761,36 +752,28 @@ final class ExplicitModuleBuildTests: XCTestCase {
           if relativeOutputPathFileName.starts(with: "A-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("A"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "B-") {
+          } else if relativeOutputPathFileName.starts(with: "B-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("B"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "C-") {
+          } else if relativeOutputPathFileName.starts(with: "C-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("C"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "D-") {
+          } else if relativeOutputPathFileName.starts(with: "D-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("D"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "G-") {
+          } else if relativeOutputPathFileName.starts(with: "G-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("G"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "F-") {
+          } else if relativeOutputPathFileName.starts(with: "F-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("F"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
+          } else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
+          } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else {
+          } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
         } else {
@@ -892,36 +875,28 @@ final class ExplicitModuleBuildTests: XCTestCase {
           if relativeOutputPathFileName.starts(with: "A-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("A"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "B-") {
+          } else if relativeOutputPathFileName.starts(with: "B-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("B"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "C-") {
+          } else if relativeOutputPathFileName.starts(with: "C-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("C"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "D-") {
+          } else if relativeOutputPathFileName.starts(with: "D-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("D"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "G-") {
+          } else if relativeOutputPathFileName.starts(with: "G-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("G"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "F-") {
+          } else if relativeOutputPathFileName.starts(with: "F-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("F"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
+          } else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
+          } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else {
+          } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
         // Bridging header
@@ -1025,24 +1000,19 @@ final class ExplicitModuleBuildTests: XCTestCase {
           if relativeOutputPathFileName.starts(with: "A-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("A"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "B-") {
+          } else if relativeOutputPathFileName.starts(with: "B-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("B"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "C-") {
+          } else if relativeOutputPathFileName.starts(with: "C-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("C"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
+          } else if relativeOutputPathFileName.starts(with: "SwiftShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("SwiftShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
+          } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
-          }
-          else {
+          } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
         } else {

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -251,8 +251,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let job = try XCTUnwrap(jobsInPhases.allJobs.first(where: { $0.kind == .compile }))
       // Load the dependency JSON and verify this dependency was encoded correctly
       XCTAssertJobInvocationMatches(job, .flag("-explicit-swift-module-map-file"))
-      let jsonDepsPathIndex = job.commandLine.firstIndex(of: .flag("-explicit-swift-module-map-file"))
-      let jsonDepsPathArg = job.commandLine[jsonDepsPathIndex! + 1]
+      let jsonDepsPathIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .flag("-explicit-swift-module-map-file")))
+      let jsonDepsPathArg = job.commandLine[jsonDepsPathIndex + 1]
       guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
         return XCTFail("No JSON dependency file path found.")
       }
@@ -312,10 +312,10 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let explicitDepsFlag = SwiftDriver.Job.ArgTemplate.flag(String("-explicit-swift-module-map-file"))
       XCTAssertJobInvocationMatches(compileJob0, explicitDepsFlag)
       XCTAssertJobInvocationMatches(compileJob1, explicitDepsFlag)
-      let jsonDeps0PathIndex = compileJob0.commandLine.firstIndex(of: explicitDepsFlag)
-      let jsonDeps0PathArg = compileJob0.commandLine[jsonDeps0PathIndex! + 1]
-      let jsonDeps1PathIndex = compileJob1.commandLine.firstIndex(of: explicitDepsFlag)
-      let jsonDeps1PathArg = compileJob1.commandLine[jsonDeps1PathIndex! + 1]
+      let jsonDeps0PathIndex = try XCTUnwrap(compileJob0.commandLine.firstIndex(of: explicitDepsFlag))
+      let jsonDeps0PathArg = compileJob0.commandLine[jsonDeps0PathIndex + 1]
+      let jsonDeps1PathIndex = try XCTUnwrap(compileJob1.commandLine.firstIndex(of: explicitDepsFlag))
+      let jsonDeps1PathArg = compileJob1.commandLine[jsonDeps1PathIndex + 1]
       XCTAssertEqual(jsonDeps0PathArg, jsonDeps1PathArg)
     }
   }
@@ -362,8 +362,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let explicitDepsFlag =
         SwiftDriver.Job.ArgTemplate.flag(String("-explicit-swift-module-map-file"))
       XCTAssertJobInvocationMatches(compileJob, explicitDepsFlag)
-      let jsonDepsPathIndex = compileJob.commandLine.firstIndex(of: explicitDepsFlag)
-      let jsonDepsPathArg = compileJob.commandLine[jsonDepsPathIndex! + 1]
+      let jsonDepsPathIndex = try XCTUnwrap(compileJob.commandLine.firstIndex(of: explicitDepsFlag))
+      let jsonDepsPathArg = compileJob.commandLine[jsonDepsPathIndex + 1]
       guard case .path(let jsonDepsPath) = jsonDepsPathArg else {
         return XCTFail("No JSON dependency file path found.")
       }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -49,7 +49,7 @@ throws {
           XCTAssertTrue(job.inputs.contains(typedCandidatePath))
           XCTAssertTrue(job.commandLine.contains(.flag(VirtualPath.lookup(candidatePath).description)))
         }
-        XCTAssertTrue(job.commandLine.filter {$0 == .flag("-candidate-module-file")}.count == compiledCandidateList.count)
+        XCTAssertEqual(job.commandLine.filter { $0 == .flag("-candidate-module-file") }.count, compiledCandidateList.count)
       }
     case .clang(_):
       XCTAssertEqual(job.kind, .generatePCM)
@@ -724,7 +724,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       for job in jobs {
         if (job.outputs.count == 0) {
           // This is the verify module job as it should be the only job scheduled to have no output.
-          XCTAssertTrue(job.kind == .verifyModuleInterface)
+          XCTAssertEqual(job.kind, .verifyModuleInterface)
           // Check the explicit module flags exists.
           XCTAssertJobInvocationMatches(job, .flag("-explicit-interface-module-build"))
           XCTAssertJobInvocationMatches(job, .flag("-explicit-swift-module-map-file"))
@@ -1846,8 +1846,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
             }
             lock.unlock()
           }
-          XCTAssertTrue(dependencyGraph.modules.count ==
-                        adjustedExpectedNumberOfDependencies)
+          XCTAssertEqual(dependencyGraph.modules.count, adjustedExpectedNumberOfDependencies)
         } catch {
           XCTFail("Unexpected error: \(error)")
         }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3043,7 +3043,7 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(plannedJobs[0].kind, .compile)
     XCTAssertEqual(plannedJobs[0].outputs.count, 1)
     XCTAssertTrue(matchTemporary(plannedJobs[0].outputs[0].file, "Test.o"))
-    XCTAssert(!plannedJobs[0].commandLine.contains(.flag("-primary-file")))
+    XCTAssertFalse(plannedJobs[0].commandLine.contains(.flag("-primary-file")))
 
     let emitModuleJob = try plannedJobs.findJob(.emitModule)
     XCTAssertEqual(emitModuleJob.outputs.count, driver1.targetTriple.isDarwin ? 8 : 7)
@@ -3057,7 +3057,7 @@ final class SwiftDriverTests: XCTestCase {
     if driver1.targetTriple.isDarwin {
         XCTAssertEqual(emitModuleJob.outputs[7].file, try toPath("Test.abi.json"))
     }
-    XCTAssert(!emitModuleJob.commandLine.contains(.flag("-primary-file")))
+    XCTAssertFalse(emitModuleJob.commandLine.contains(.flag("-primary-file")))
     XCTAssertJobInvocationMatches(emitModuleJob, .flag("-emit-module-interface-path"))
     XCTAssertJobInvocationMatches(emitModuleJob, .flag("-emit-private-module-interface-path"))
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3058,8 +3058,8 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertEqual(emitModuleJob.outputs[7].file, try toPath("Test.abi.json"))
     }
     XCTAssert(!emitModuleJob.commandLine.contains(.flag("-primary-file")))
-    XCTAssert(emitModuleJob.commandLine.contains(.flag("-emit-module-interface-path")))
-    XCTAssert(emitModuleJob.commandLine.contains(.flag("-emit-private-module-interface-path")))
+    XCTAssertJobInvocationMatches(emitModuleJob, .flag("-emit-module-interface-path"))
+    XCTAssertJobInvocationMatches(emitModuleJob, .flag("-emit-private-module-interface-path"))
   }
 
 


### PR DESCRIPTION
Various changes to clean up the test suite implementation.
- Adopt `XCTAssertJobInvocationMatches` in more test cases
- Replace use of `XCTAssert(... == ...)` in favour of `XCTAssertEqual`
- Replace use of `XCTAssertTrue(!...)` in favour of `XCTAssertFalse`
- Some stylistic compression of `... ; return`
- Coddle braces as per Swift style
- Adopt `XCTUnwrap` in a number of test cases

The majority of this change is intended to reduce the LoC and ease debugging by allowing the test failure to indicate what the expectation vs computed values are. Additionally, it makes the test suite run to completion in more cases by removing forced unwraps.