### PR TITLE
Update some uses of `ProcessEnv.vars` to `ProcessEnv.block`

### DIFF
--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -41,7 +41,7 @@ func getArgument(_ flag: String, _ env: String? = nil) -> String? {
     }
   }
   if let env = env {
-    return ProcessEnv.vars[env]
+    return ProcessEnv.block[.init(env)]
   }
   return nil
 }
@@ -92,9 +92,8 @@ do {
   if !localFileSystem.exists(outputDir) {
     try localFileSystem.createDirectory(outputDir, recursive: true)
   }
-  let swiftcPathRaw = ProcessEnv.vars["SWIFT_EXEC"]
   var swiftcPath: AbsolutePath
-  if let swiftcPathRaw = swiftcPathRaw {
+  if let swiftcPathRaw = ProcessEnv.block["SWIFT_EXEC"] {
     let virtualPath = try VirtualPath(path: swiftcPathRaw)
     guard let absolutePath = virtualPath.absolutePath else {
       diagnosticsEngine.emit(error: "value of SWIFT_EXEC is not a valid absolute path: \(swiftcPathRaw)")

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -73,7 +73,7 @@ do {
 
   // Fallback to legacy driver if forced to
   if CommandLine.arguments.contains(Option.disallowForwardingDriver.spelling) ||
-     ProcessEnv.vars["SWIFT_USE_OLD_DRIVER"] != nil {
+     ProcessEnv.block["SWIFT_USE_OLD_DRIVER"] != nil {
     // If CommandLine.argument[0] is not an absolute path, we would form a path
     // relative to the current directory rather than relative to the actual
     // location of the binary. Use the Founation `NSProcessInfo` type to compute
@@ -113,7 +113,7 @@ do {
     }
   }
 
-  if ProcessEnv.vars["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {
+  if ProcessEnv.block["SWIFT_ENABLE_EXPLICIT_MODULE"] != nil {
     CommandLine.arguments.append("-explicit-module-build")
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5385,8 +5385,8 @@ final class SwiftDriverTests: XCTestCase {
 
   func testToolchainClangPath() throws {
     // Overriding the swift executable to a specific location breaks this.
-    guard ProcessEnv.vars["SWIFT_DRIVER_SWIFT_EXEC"] == nil,
-          ProcessEnv.vars["SWIFT_DRIVER_SWIFT_FRONTEND_EXEC"] == nil else {
+    guard ProcessEnv.block["SWIFT_DRIVER_SWIFT_EXEC"] == nil,
+          ProcessEnv.block["SWIFT_DRIVER_SWIFT_FRONTEND_EXEC"] == nil else {
       return
     }
     // TODO: remove this conditional check once DarwinToolchain does not requires xcrun to look for clang.

--- a/Tests/TestUtilities/DriverExtensions.swift
+++ b/Tests/TestUtilities/DriverExtensions.swift
@@ -49,7 +49,7 @@ extension Driver {
 /// Set to nil if cannot perform on this host
 private let cachedSDKPath: Result<String, Error>? = {
   #if os(Windows)
-  if let sdk = ProcessEnv.vars["SDKROOT"] {
+  if let sdk = ProcessEnv.block["SDKROOT"] {
     return Result{sdk}
   }
   // Assume that if neither of the environment variables are set, we are


### PR DESCRIPTION
The new `ProcessEnvironmentBlock` allows for better handling of the environment block on Windows. This cleans up some of the warnings emitted when building. A more thorough replacement requires changing the APIs to replace usage in the `SwiftDriver.init` method.