### PR TITLE
Tests: further cleanups

### DIFF
--- a/Tests/SwiftDriverTests/APIDigesterTests.swift
+++ b/Tests/SwiftDriverTests/APIDigesterTests.swift
@@ -204,8 +204,7 @@ class APIDigesterTests: XCTestCase {
                                      source.pathString,
                                      "-emit-module",
                                      "-emit-digester-baseline",
-                                    ],
-                              env: ProcessEnv.vars)
+                                    ])
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
@@ -285,8 +284,7 @@ class APIDigesterTests: XCTestCase {
                                      source.pathString,
                                      "-emit-module",
                                      "-emit-digester-baseline"
-                                    ],
-                              env: ProcessEnv.vars)
+                                    ])
       guard driver.supportedFrontendFlags.contains("disable-fail-on-error") else {
         throw XCTSkip("Skipping: swift-api-digester does not support '-disable-fail-on-error'")
       }
@@ -309,8 +307,7 @@ class APIDigesterTests: XCTestCase {
                                       path.appending(component: "foo.api.json").pathString,
                                       "-serialize-breaking-changes-path",
                                       path.appending(component: "changes.dia").pathString
-                                     ],
-                              env: ProcessEnv.vars)
+                                     ])
       let jobs2 = try driver2.planBuild()
       try driver2.run(jobs: jobs2)
       XCTAssertFalse(driver2.diagnosticEngine.hasErrors)
@@ -354,8 +351,7 @@ class APIDigesterTests: XCTestCase {
                                      "-enable-library-evolution",
                                      "-emit-digester-baseline",
                                      "-digester-mode", "abi"
-                                    ],
-                              env: ProcessEnv.vars)
+                                    ])
       guard driver.supportedFrontendFlags.contains("disable-fail-on-error") else {
         throw XCTSkip("Skipping: swift-api-digester does not support '-disable-fail-on-error'")
       }
@@ -385,8 +381,7 @@ class APIDigesterTests: XCTestCase {
                                       "-digester-breakage-allowlist-path",
                                       allowlist.pathString,
                                       "-digester-mode", "abi"
-                                     ],
-                              env: ProcessEnv.vars)
+                                     ])
       let jobs2 = try driver2.planBuild()
       try driver2.run(jobs: jobs2)
       XCTAssertFalse(driver2.diagnosticEngine.hasErrors)

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -49,7 +49,7 @@ throws {
           XCTAssertTrue(job.inputs.contains(typedCandidatePath))
           XCTAssertTrue(job.commandLine.contains(.flag(VirtualPath.lookup(candidatePath).description)))
         }
-        XCTAssertTrue(job.commandLine.filter {$0 == .flag("-candidate-module-file")}.count == compiledCandidateList.count)
+        XCTAssertEqual(job.commandLine.filter { $0 == .flag("-candidate-module-file") }.count, compiledCandidateList.count)
       }
       // make sure command-line from dep-scanner are included.
       let extraCommandLine = try XCTUnwrap(swiftModuleDetails.commandLine)
@@ -512,7 +512,7 @@ final class CachingBuildTests: XCTestCase {
       for job in jobs {
         if (job.outputs.count == 0) {
           // This is the verify module job as it should be the only job scheduled to have no output.
-          XCTAssertTrue(job.kind == .verifyModuleInterface)
+          XCTAssertEqual(job.kind, .verifyModuleInterface)
           // Check the explicit module flags exists.
           XCTAssertTrue(job.commandLine.contains(.flag(String("-explicit-interface-module-build"))))
           XCTAssertTrue(job.commandLine.contains(.flag(String("-explicit-swift-module-map-file"))))

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -125,7 +125,7 @@ private func checkCASForResults(jobs: [Job], cas: SwiftScanCAS, fs: FileSystem) 
           try await compilation.makeGlobal()
           // Execise call back uploading method.
           compilation.makeGlobal { error in
-            XCTAssertTrue(error == nil, "Upload Error")
+            XCTAssertNil(error, "Upload Error")
           }
           compilations.append(compilation)
         } else {

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -386,7 +386,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-emit-module", "-o", modulePath.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true), other.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -444,7 +443,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-Xfrontend", "-disable-implicit-concurrency-module-import",
                                      "-Xfrontend", "-disable-implicit-string-processing-module-import",
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       for job in jobs {
@@ -635,7 +633,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
@@ -692,7 +689,6 @@ final class CachingBuildTests: XCTestCase {
                                              "-pch-output-dir", PCHPath.nativePathString(escaped: true),
                                              FooInstallPath.appending(component: "Foo.swiftmodule").nativePathString(escaped: true)]
                                       + sdkArgumentsForTesting,
-                                      env: ProcessEnv.vars,
                                       interModuleDependencyOracle: dependencyOracle)
 
       let scanLibPath = try XCTUnwrap(fooBuildDriver.getSwiftScanLibPath())
@@ -721,7 +717,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       // This is currently not supported.
       XCTAssertThrowsError(try driver.planBuild()) {
@@ -760,7 +755,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-Xcc", "-ivfsoverlay", "-Xcc", vfsoverlay.nativePathString(escaped: true),
                                      "-disable-clang-target",
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       let scanLibPath = try XCTUnwrap(driver.getSwiftScanLibPath())
       try dependencyOracle.verifyOrCreateScannerInstance(swiftScanLibPath: scanLibPath)
@@ -908,7 +902,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-scanner-prefix-map", testInputsPath.description + "=/^src",
                                      "-scanner-prefix-map", path.description + "=/^tmp",
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       guard driver.isFrontendArgSupported(.scannerPrefixMap) else {
         throw XCTSkip("frontend doesn't support prefix map")
@@ -973,7 +966,6 @@ final class CachingBuildTests: XCTestCase {
                                      "-output-file-map", ofm.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars,
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -475,7 +475,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         case .swift("testExplicitLinkLibraries"):
           let linkLibraries = try XCTUnwrap(depInfo.linkLibraries)
           if driver.targetTriple.isDarwin {
-            XCTAssertTrue(!linkLibraries.isEmpty)
+            XCTAssertFalse(linkLibraries.isEmpty)
             XCTAssertTrue(linkLibraries.contains { $0.linkName == "objc" })
           }
         default:
@@ -2400,8 +2400,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertEqual(getInputModules(HJobs[1]), ["A", "E", "F", "G", "Swift"])
       // x86_64
       XCTAssertEqual(getInputModules(HJobs[2]), ["A", "E", "F", "G", "Swift"])
-      XCTAssertTrue(getOutputName(HJobs[0]) != getOutputName(HJobs[1]))
-      XCTAssertTrue(getOutputName(HJobs[1]) != getOutputName(HJobs[2]))
+      XCTAssertNotEqual(getOutputName(HJobs[0]), getOutputName(HJobs[1]))
+      XCTAssertNotEqual(getOutputName(HJobs[1]), getOutputName(HJobs[2]))
       checkInputOutputIntegrity(HJobs[0])
       checkInputOutputIntegrity(HJobs[1])
       checkInputOutputIntegrity(HJobs[2])
@@ -2410,8 +2410,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertEqual(getInputModules(GJobs[0]), ["E", "E", "Swift", "Swift"])
       XCTAssertEqual(getInputModules(GJobs[1]), ["E", "Swift"])
       XCTAssertEqual(getInputModules(GJobs[2]), ["E", "Swift"])
-      XCTAssertTrue(getOutputName(GJobs[0]) != getOutputName(GJobs[1]))
-      XCTAssertTrue(getOutputName(GJobs[1]) != getOutputName(GJobs[2]))
+      XCTAssertNotEqual(getOutputName(GJobs[0]), getOutputName(GJobs[1]))
+      XCTAssertNotEqual(getOutputName(GJobs[1]), getOutputName(GJobs[2]))
       checkInputOutputIntegrity(GJobs[0])
       checkInputOutputIntegrity(GJobs[1])
     }
@@ -2439,7 +2439,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertEqual(getInputModules(HJobs[1]), ["A", "E", "F", "G", "Swift"])
       // x86_64
       XCTAssertEqual(getInputModules(HJobs[2]), ["A", "E", "F", "G", "Swift"])
-      XCTAssertTrue(getOutputName(HJobs[0]) != getOutputName(HJobs[1]))
+      XCTAssertNotEqual(getOutputName(HJobs[0]), getOutputName(HJobs[1]))
       checkInputOutputIntegrity(HJobs[0])
       checkInputOutputIntegrity(HJobs[1])
 
@@ -2448,8 +2448,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertEqual(getInputModules(GJobs[0]), ["E", "E", "Swift", "Swift"])
       XCTAssertEqual(getInputModules(GJobs[1]), ["E", "Swift"])
       XCTAssertEqual(getInputModules(GJobs[2]), ["E", "Swift"])
-      XCTAssertTrue(getOutputName(GJobs[0]) != getOutputName(GJobs[1]))
-      XCTAssertTrue(getOutputName(GJobs[1]) != getOutputName(GJobs[2]))
+      XCTAssertNotEqual(getOutputName(GJobs[0]), getOutputName(GJobs[1]))
+      XCTAssertNotEqual(getOutputName(GJobs[1]), getOutputName(GJobs[2]))
       checkInputOutputIntegrity(GJobs[0])
       checkInputOutputIntegrity(GJobs[1])
     }
@@ -2514,7 +2514,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let (baseline, current) = (job.inputs[0], job.inputs[1])
       XCTAssertEqual(baseline.type, .jsonABIBaseline)
       XCTAssertEqual(current.type, .jsonABIBaseline)
-      XCTAssertTrue(current.file != baseline.file)
+      XCTAssertNotEqual(current.file, baseline.file)
       XCTAssertEqual(current.file.basename, baseline.file.basename)
     }
     let mockSDKPath: String =

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -2309,13 +2309,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }
 
     func getOutputName(_ job: Job) -> String {
-      XCTAssertTrue(job.outputs.count == 1)
+      XCTAssertEqual(job.outputs.count, 1)
       return job.outputs[0].file.basename
     }
 
     func checkInputOutputIntegrity(_ job: Job) {
       let name = job.outputs[0].file.basenameWithoutExt
-      XCTAssertTrue(job.outputs[0].file.extension == "swiftmodule")
+      XCTAssertEqual(job.outputs[0].file.extension, "swiftmodule")
       job.inputs.forEach { input in
         // Inputs include all the dependencies and the interface from where
         // the current module can be built.
@@ -2326,7 +2326,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         if inputName.starts(with: "arm64e-") && name.starts(with: "arm64-") {
           return
         }
-        XCTAssertTrue(inputName == name)
+        XCTAssertEqual(inputName, name)
       }
     }
 
@@ -2352,12 +2352,12 @@ final class ExplicitModuleBuildTests: XCTestCase {
     }()
 
     // Check interface map always contain everything
-    XCTAssertTrue(interfaceMap["Swift"]!.count == 3)
-    XCTAssertTrue(interfaceMap["A"]!.count == 3)
-    XCTAssertTrue(interfaceMap["E"]!.count == 3)
-    XCTAssertTrue(interfaceMap["F"]!.count == 3)
-    XCTAssertTrue(interfaceMap["G"]!.count == 3)
-    XCTAssertTrue(interfaceMap["H"]!.count == 3)
+    XCTAssertEqual(interfaceMap["Swift"]?.count, 3)
+    XCTAssertEqual(interfaceMap["A"]?.count, 3)
+    XCTAssertEqual(interfaceMap["E"]?.count, 3)
+    XCTAssertEqual(interfaceMap["F"]?.count, 3)
+    XCTAssertEqual(interfaceMap["G"]?.count, 3)
+    XCTAssertEqual(interfaceMap["H"]?.count, 3)
 
     try withTemporaryDirectory { path in
       let main = path.appending(component: "testPrebuiltModuleGenerationJobs.swift")
@@ -2381,11 +2381,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                                                                 into: path,
                                                                                 exhaustive: true)
 
-      XCTAssertTrue(danglingJobs.count == 2)
+      XCTAssertEqual(danglingJobs.count, 2)
       XCTAssertTrue(danglingJobs.allSatisfy { job in
         job.moduleName == "MissingKit"
       })
-      XCTAssertTrue(jobs.count == 18)
+      XCTAssertEqual(jobs.count, 18)
       XCTAssertTrue(jobs.allSatisfy {$0.outputs.count == 1})
       XCTAssertTrue(jobs.allSatisfy {$0.kind == .compile})
       XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-compile-module-from-interface"))})
@@ -2393,23 +2393,23 @@ final class ExplicitModuleBuildTests: XCTestCase {
       XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-bad-file-descriptor-retry-count"))})
       XCTAssertTrue(try jobs.allSatisfy {$0.commandLine.contains(.path(try VirtualPath(path: moduleCachePath)))})
       let HJobs = jobs.filter { $0.moduleName == "H"}
-      XCTAssertTrue(HJobs.count == 3)
+      XCTAssertEqual(HJobs.count, 3)
       // arm64
-      XCTAssertTrue(getInputModules(HJobs[0]) == ["A", "A", "E", "E", "F", "F", "G", "G", "Swift", "Swift"])
+      XCTAssertEqual(getInputModules(HJobs[0]), ["A", "A", "E", "E", "F", "F", "G", "G", "Swift", "Swift"])
       // arm64e
-      XCTAssertTrue(getInputModules(HJobs[1]) == ["A", "E", "F", "G", "Swift"])
+      XCTAssertEqual(getInputModules(HJobs[1]), ["A", "E", "F", "G", "Swift"])
       // x86_64
-      XCTAssertTrue(getInputModules(HJobs[2]) == ["A", "E", "F", "G", "Swift"])
+      XCTAssertEqual(getInputModules(HJobs[2]), ["A", "E", "F", "G", "Swift"])
       XCTAssertTrue(getOutputName(HJobs[0]) != getOutputName(HJobs[1]))
       XCTAssertTrue(getOutputName(HJobs[1]) != getOutputName(HJobs[2]))
       checkInputOutputIntegrity(HJobs[0])
       checkInputOutputIntegrity(HJobs[1])
       checkInputOutputIntegrity(HJobs[2])
       let GJobs = jobs.filter { $0.moduleName == "G"}
-      XCTAssertTrue(GJobs.count == 3)
-      XCTAssertTrue(getInputModules(GJobs[0]) == ["E", "E", "Swift", "Swift"])
-      XCTAssertTrue(getInputModules(GJobs[1]) == ["E", "Swift"])
-      XCTAssertTrue(getInputModules(GJobs[2]) == ["E", "Swift"])
+      XCTAssertEqual(GJobs.count, 3)
+      XCTAssertEqual(getInputModules(GJobs[0]), ["E", "E", "Swift", "Swift"])
+      XCTAssertEqual(getInputModules(GJobs[1]), ["E", "Swift"])
+      XCTAssertEqual(getInputModules(GJobs[2]), ["E", "Swift"])
       XCTAssertTrue(getOutputName(GJobs[0]) != getOutputName(GJobs[1]))
       XCTAssertTrue(getOutputName(GJobs[1]) != getOutputName(GJobs[2]))
       checkInputOutputIntegrity(GJobs[0])
@@ -2426,26 +2426,28 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                                                                 exhaustive: false)
 
       XCTAssertTrue(danglingJobs.isEmpty)
-      XCTAssertTrue(jobs.count == 18)
+      XCTAssertEqual(jobs.count, 18)
       XCTAssertTrue(jobs.allSatisfy {$0.outputs.count == 1})
       XCTAssertTrue(jobs.allSatisfy {$0.kind == .compile})
       XCTAssertTrue(jobs.allSatisfy {$0.commandLine.contains(.flag("-compile-module-from-interface"))})
+
       let HJobs = jobs.filter { $0.moduleName == "H"}
-      XCTAssertTrue(HJobs.count == 3)
+      XCTAssertEqual(HJobs.count, 3)
       // arm64
-      XCTAssertTrue(getInputModules(HJobs[0]) == ["A", "A", "E", "E", "F", "F", "G", "G", "Swift", "Swift"])
+      XCTAssertEqual(getInputModules(HJobs[0]), ["A", "A", "E", "E", "F", "F", "G", "G", "Swift", "Swift"])
       // arm64e
-      XCTAssertTrue(getInputModules(HJobs[1]) == ["A", "E", "F", "G", "Swift"])
+      XCTAssertEqual(getInputModules(HJobs[1]), ["A", "E", "F", "G", "Swift"])
       // x86_64
-      XCTAssertTrue(getInputModules(HJobs[2]) == ["A", "E", "F", "G", "Swift"])
+      XCTAssertEqual(getInputModules(HJobs[2]), ["A", "E", "F", "G", "Swift"])
       XCTAssertTrue(getOutputName(HJobs[0]) != getOutputName(HJobs[1]))
       checkInputOutputIntegrity(HJobs[0])
       checkInputOutputIntegrity(HJobs[1])
+
       let GJobs = jobs.filter { $0.moduleName == "G"}
-      XCTAssertTrue(GJobs.count == 3)
-      XCTAssertTrue(getInputModules(GJobs[0]) == ["E", "E", "Swift", "Swift"])
-      XCTAssertTrue(getInputModules(GJobs[1]) == ["E", "Swift"])
-      XCTAssertTrue(getInputModules(GJobs[2]) == ["E", "Swift"])
+      XCTAssertEqual(GJobs.count, 3)
+      XCTAssertEqual(getInputModules(GJobs[0]), ["E", "E", "Swift", "Swift"])
+      XCTAssertEqual(getInputModules(GJobs[1]), ["E", "Swift"])
+      XCTAssertEqual(getInputModules(GJobs[2]), ["E", "Swift"])
       XCTAssertTrue(getOutputName(GJobs[0]) != getOutputName(GJobs[1]))
       XCTAssertTrue(getOutputName(GJobs[1]) != getOutputName(GJobs[2]))
       checkInputOutputIntegrity(GJobs[0])
@@ -2476,7 +2478,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                                                                 exhaustive: false)
 
       XCTAssertTrue(danglingJobs.isEmpty)
-      XCTAssertTrue(jobs.count == 9)
+      XCTAssertEqual(jobs.count, 9)
       jobs.forEach({ job in
         // Check we don't pull in other modules than A, F and Swift
         XCTAssertTrue(["A", "F", "Swift"].contains(job.moduleName))
@@ -2507,13 +2509,13 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
   func testABICheckWhileBuildingPrebuiltModule() throws {
     func checkABICheckingJob(_ job: Job) throws {
-      XCTAssertTrue(job.kind == .compareABIBaseline)
-      XCTAssertTrue(job.inputs.count == 2)
+      XCTAssertEqual(job.kind, .compareABIBaseline)
+      XCTAssertEqual(job.inputs.count, 2)
       let (baseline, current) = (job.inputs[0], job.inputs[1])
-      XCTAssertTrue(baseline.type == .jsonABIBaseline)
-      XCTAssertTrue(current.type == .jsonABIBaseline)
+      XCTAssertEqual(baseline.type, .jsonABIBaseline)
+      XCTAssertEqual(current.type, .jsonABIBaseline)
       XCTAssertTrue(current.file != baseline.file)
-      XCTAssertTrue(current.file.basename == baseline.file.basename)
+      XCTAssertEqual(current.file.basename, baseline.file.basename)
     }
     let mockSDKPath: String =
         try testInputsPath.appending(component: "mock-sdk.sdk").pathString

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -424,7 +424,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         throw XCTSkip("libSwiftScan does not support link library reporting.")
       }
 
-      var args = ["swiftc",
+      let args = ["swiftc",
                   "-I", cHeadersPath.nativePathString(escaped: true),
                   "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                   "-explicit-module-build",

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -642,23 +642,20 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                  "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                  "-working-directory", path.nativePathString(escaped: true),
                                  main.nativePathString(escaped: true)] + sdkArgumentsForTesting
-      var driver = try Driver(args: invocationArguments,
-                              env: ProcessEnv.vars)
+      var driver = try Driver(args: invocationArguments)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
 
       // Plan the same build one more time and ensure it does not contain dependency compilation jobs
-      var incrementalDriver = try Driver(args: invocationArguments,
-                                         env: ProcessEnv.vars)
+      var incrementalDriver = try Driver(args: invocationArguments)
       let incrementalJobs = try incrementalDriver.planBuild()
       XCTAssertFalse(incrementalJobs.contains { $0.kind == .generatePCM })
       XCTAssertFalse(incrementalJobs.contains { $0.kind == .compileModuleFromInterface })
 
       // Ensure that passing '-always-rebuild-module-dependencies' results in re-building module dependencies
       // even when up-to-date.
-      var incrementalAlwaysRebuildDriver = try Driver(args: invocationArguments + ["-always-rebuild-module-dependencies"],
-                                                      env: ProcessEnv.vars)
+      var incrementalAlwaysRebuildDriver = try Driver(args: invocationArguments + ["-always-rebuild-module-dependencies"])
       let incrementalAlwaysRebuildJobs = try incrementalAlwaysRebuildDriver.planBuild()
       XCTAssertFalse(incrementalAlwaysRebuildDriver.diagnosticEngine.hasErrors)
       XCTAssertTrue(incrementalAlwaysRebuildJobs.contains { $0.kind == .generatePCM })
@@ -1058,8 +1055,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-module-cache-path", path.nativePathString(escaped: true),
                                      "-I", stdLibPath.nativePathString(escaped: true),
                                      "-I", shimsPath.nativePathString(escaped: true),
-                              ] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                              ] + sdkArgumentsForTesting)
       guard driver.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
       }
@@ -1276,8 +1272,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       srcBar.nativePathString(escaped: true),
                                       "-I", stdLibPath.nativePathString(escaped: true),
                                       "-I", shimsPath.nativePathString(escaped: true),
-                                     ] + sdkArgumentsForTesting,
-                               env: ProcessEnv.vars)
+                                     ] + sdkArgumentsForTesting)
       guard driver1.isFrontendArgSupported(.moduleAlias) else {
         throw XCTSkip("Skipping: compiler does not support '-module-alias'")
       }
@@ -1315,8 +1310,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       srcFoo.nativePathString(escaped: true),
                                       "-I", stdLibPath.nativePathString(escaped: true),
                                       "-I", shimsPath.nativePathString(escaped: true),
-                                      ] + sdkArgumentsForTesting,
-                               env: ProcessEnv.vars)
+                                      ] + sdkArgumentsForTesting)
       let jobs2 = try driver2.planBuild()
       try driver2.run(jobs: jobs2)
       XCTAssertFalse(driver2.diagnosticEngine.hasErrors)
@@ -1351,8 +1345,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-explicit-module-build",
                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       try driver.run(jobs: jobs)
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
@@ -1390,8 +1383,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                         frameworkModulePath.nativePathString(escaped: true),
                                         "-working-directory",
                                         path.nativePathString(escaped: true),
-                                        fooSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                                 env: ProcessEnv.vars)
+                                        fooSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let jobs = try driverFoo.planBuild()
       try driverFoo.run(jobs: jobs)
       XCTAssertFalse(driverFoo.diagnosticEngine.hasErrors)
@@ -1411,8 +1403,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-explicit-module-build",
                                      "-module-name", "main",
                                      "-working-directory", path.nativePathString(escaped: true),
-                                     mainSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     mainSourcePath.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       if scannerCommand.first == "-frontend" {
@@ -1503,8 +1494,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + lotsOfInputs + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     main.nativePathString(escaped: true)] + lotsOfInputs + sdkArgumentsForTesting)
       let scannerJob = try driver.dependencyScanningJob()
 
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
@@ -1529,8 +1519,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-module-cache-path",
                                      moduleCachePath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       guard driver.isFrontendArgSupported(.clangScannerModuleCachePath) else {
         throw XCTSkip("Skipping: compiler does not support '-clang-scanner-module-cache-path'")
       }
@@ -1572,8 +1561,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       if scannerCommand.first == "-frontend" {
@@ -1645,8 +1633,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       if scannerCommand.first == "-frontend" {
@@ -1737,8 +1724,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-explicit-module-build",
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target",
-                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       // We generate full swiftc -frontend -scan-dependencies invocations in order to also be
@@ -1920,8 +1906,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                       ["-module-name","testParallelDependencyScanningDiagnostics\(fileIndex)"] +
                                        // FIXME: We need to differentiate the scanning action hash,
                                        // though the module-name above should be sufficient.
-                                      ["-I/tmp/foo/bar/\(fileIndex)"],
-                                env: ProcessEnv.vars)
+                                      ["-I/tmp/foo/bar/\(fileIndex)"])
         var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
         if scannerCommand.first == "-frontend" {
           scannerCommand.removeFirst()
@@ -2102,8 +2087,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-explicit-module-build",
                                        "-working-directory", path.nativePathString(escaped: true),
                                        "-disable-clang-target",
-                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                                env: ProcessEnv.vars)
+                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
         let resolver = try ArgsResolver(fileSystem: localFileSystem)
         var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
         if scannerCommand.first == "-frontend" {
@@ -2232,8 +2216,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                        "-working-directory", path.nativePathString(escaped: true),
                                        "-explain-module-dependency-detailed", "A",
-                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                                env: ProcessEnv.vars)
+                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
         let jobs = try driver.planBuild()
         try driver.run(jobs: jobs)
         XCTAssertTrue(!driver.diagnosticEngine.diagnostics.isEmpty)
@@ -2260,8 +2243,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                        "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                        "-working-directory", path.nativePathString(escaped: true),
                                        "-explain-module-dependency", "A",
-                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                                env: ProcessEnv.vars)
+                                       main.nativePathString(escaped: true)] + sdkArgumentsForTesting)
         let jobs = try driver.planBuild()
         try driver.run(jobs: jobs)
         XCTAssertTrue(!driver.diagnosticEngine.diagnostics.isEmpty)
@@ -2306,8 +2288,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-emit-module", outputModule.nativePathString(escaped: true),
                                      "-experimental-emit-module-separately",
-                                     fileA.nativePathString(escaped: true), fileB.nativePathString(escaped: true)] + sdkArgumentsForTesting,
-                              env: ProcessEnv.vars)
+                                     fileA.nativePathString(escaped: true), fileB.nativePathString(escaped: true)] + sdkArgumentsForTesting)
       let jobs = try driver.planBuild()
       let compileJobs = jobs.filter({ $0.kind == .compile })
       XCTAssertEqual(compileJobs.count, 0)

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -141,7 +141,7 @@ final class IncrementalCompilationTests: XCTestCase {
       }
     }
 
-    let driver = try! Driver(args: ["swiftc", "-v"])
+    let driver = try! Driver(args: ["swiftc"])
     if driver.isFrontendArgSupported(.moduleLoadMode) {
       self.extraExplicitBuildArgs = ["-Xfrontend", "-module-load-mode", "-Xfrontend", "prefer-interface"]
     }

--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -1665,7 +1665,7 @@ extension IncrementalCompilationTests {
     let diagnosticEngine = DiagnosticsEngine(handlers: [
       {print($0, to: &stderrStream); stderrStream.flush()}
     ])
-    var driver = try Driver(args: arguments, env: ProcessEnv.vars,
+    var driver = try Driver(args: arguments,
                             diagnosticsEngine: diagnosticEngine,
                             fileSystem: localFileSystem)
     doTheCompile(&driver)

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -353,7 +353,8 @@ final class JobExecutorTests: XCTestCase {
 
       var driver = try Driver(args: ["swift", main.pathString])
       let jobs = try driver.planBuild()
-      XCTAssertTrue(jobs.count == 1 && jobs[0].requiresInPlaceExecution)
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertTrue(jobs[0].requiresInPlaceExecution)
 
       // Change the file
       try localFileSystem.writeFileContents(main, bytes: "let foo = 1")

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -483,7 +483,6 @@ final class JobExecutorTests: XCTestCase {
         var driver = try Driver(args: ["swiftc", main.pathString,
                                        "-driver-filelist-threshold", "0",
                                        "-o", outputPath.pathString] + getHostToolchainSdkArg(executor),
-                                env: ProcessEnv.vars,
                                 diagnosticsOutput: .engine(diags),
                                 fileSystem: localFileSystem,
                                 executor: executor)
@@ -519,7 +518,6 @@ final class JobExecutorTests: XCTestCase {
                                        "-save-temps",
                                        "-driver-filelist-threshold", "0",
                                        "-o", outputPath.pathString] + getHostToolchainSdkArg(executor),
-                                env: ProcessEnv.vars,
                                 diagnosticsOutput: .engine(diags),
                                 fileSystem: localFileSystem,
                                 executor: executor)
@@ -555,7 +553,6 @@ final class JobExecutorTests: XCTestCase {
                                        "-driver-filelist-threshold", "0",
                                        "-Xfrontend", "-debug-crash-immediately",
                                        "-o", outputPath.pathString] + getHostToolchainSdkArg(executor),
-                                env: ProcessEnv.vars,
                                 diagnosticsOutput: .engine(diags),
                                 fileSystem: localFileSystem,
                                 executor: executor)

--- a/Tests/SwiftDriverTests/ParsableMessageTests.swift
+++ b/Tests/SwiftDriverTests/ParsableMessageTests.swift
@@ -413,7 +413,6 @@ final class ParsableMessageTests: XCTestCase {
           let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
           var driver = try Driver(args: ["swiftc", main.pathString,
                                          "-o", output.pathString] + sdkArgumentsForTesting,
-                                  env: ProcessEnv.vars,
                                   diagnosticsEngine: diags,
                                   fileSystem: localFileSystem,
                                   integratedDriver: true)
@@ -438,7 +437,6 @@ final class ParsableMessageTests: XCTestCase {
           var driver = try Driver(args: ["swiftc", main.pathString,
                                          "-use-frontend-parseable-output",
                                          "-o", output.pathString] + sdkArgumentsForTesting,
-                                  env: ProcessEnv.vars,
                                   diagnosticsEngine: diags,
                                   fileSystem: localFileSystem,
                                   integratedDriver: false)

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1705,11 +1705,12 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift"] + manyArgs + ["/foo.swift"])
       let jobs = try driver.planBuild()
-      XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .interpret)
       let interpretJob = jobs[0]
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob)
-      XCTAssertTrue(resolvedArgs.count == 3)
+      XCTAssertEqual(resolvedArgs.count, 3)
       XCTAssertEqual(resolvedArgs[1], "-frontend")
       XCTAssertEqual(resolvedArgs[2].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
@@ -1723,7 +1724,8 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift"] + manyArgs + ["foo.swift"])
       let jobs = try driver.planBuild()
-      XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .interpret)
       let interpretJob = jobs[0]
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob, useResponseFiles: .disabled)
@@ -1734,11 +1736,12 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift"] + ["/foo.swift"])
       let jobs = try driver.planBuild()
-      XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .interpret)
       let interpretJob = jobs[0]
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob, useResponseFiles: .forced)
-      XCTAssertTrue(resolvedArgs.count == 3)
+      XCTAssertEqual(resolvedArgs.count, 3)
       XCTAssertEqual(resolvedArgs[1], "-frontend")
       XCTAssertEqual(resolvedArgs[2].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
@@ -1750,7 +1753,8 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift"] + ["foo.swift"])
       let jobs = try driver.planBuild()
-      XCTAssertTrue(jobs.count == 1 && jobs[0].kind == .interpret)
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .interpret)
       let interpretJob = jobs[0]
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: interpretJob)
@@ -3076,7 +3080,7 @@ final class SwiftDriverTests: XCTestCase {
     // Make sure the supplementary output map has an entry for the Swift file
     // under indexing and its indexData entry is the primary output file
     let entry = try XCTUnwrap(map.entries[VirtualPath.absolute(try AbsolutePath(validating: "/tmp/foo5.swift")).intern()])
-    XCTAssert(VirtualPath.lookup(entry[.indexData]!) == .absolute(try .init(validating: "/tmp/t.o")))
+    XCTAssertEqual(VirtualPath.lookup(entry[.indexData]!), .absolute(try .init(validating: "/tmp/t.o")))
   }
 
   func testMultiThreadedWholeModuleOptimizationCompiles() throws {
@@ -5560,7 +5564,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-apple-ios13.1-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-sdk", "bar", "-resource-dir", "baz"])
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertEqual(job.kind, .printTargetInfo)
       XCTAssertJobInvocationMatches(job, .flag("-print-target-info"))
@@ -5573,7 +5577,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-unknown-linux"])
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertEqual(job.kind, .printTargetInfo)
       XCTAssertJobInvocationMatches(job, .flag("-print-target-info"))
@@ -5584,7 +5588,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-unknown-linux", "-static-stdlib"])
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertEqual(job.kind, .printTargetInfo)
       XCTAssertJobInvocationMatches(job, .flag("-print-target-info"))
@@ -5595,7 +5599,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-unknown-linux", "-static-executable"])
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertEqual(job.kind, .printTargetInfo)
       XCTAssertJobInvocationMatches(job, .flag("-print-target-info"))
@@ -6987,13 +6991,13 @@ final class SwiftDriverTests: XCTestCase {
       let diags = DiagnosticsEngine()
       var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-wmo", "-o", "a.out", "-module-name", "main", "-enable-library-evolution"], diagnosticsEngine: diags)
       _ = try driver.planBuild()
-      XCTAssertTrue(diags.diagnostics.first!.message.text == Diagnostic.Message.error_no_library_evolution_embedded.text)
+      XCTAssertEqual(diags.diagnostics.first!.message.text, Diagnostic.Message.error_no_library_evolution_embedded.text)
     } catch _ { }
     do {
       let diags = DiagnosticsEngine()
       var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-o", "a.out", "-module-name", "main"], diagnosticsEngine: diags)
       _ = try driver.planBuild()
-      XCTAssertTrue(diags.diagnostics.first!.message.text == Diagnostic.Message.error_need_wmo_embedded.text)
+      XCTAssertEqual(diags.diagnostics.first!.message.text, Diagnostic.Message.error_need_wmo_embedded.text)
     } catch _ { }
     do {
       // Indexing embedded Swift code should not require WMO
@@ -7006,7 +7010,7 @@ final class SwiftDriverTests: XCTestCase {
       let diags = DiagnosticsEngine()
       var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-wmo", "-o", "a.out", "-module-name", "main", "-enable-objc-interop"], diagnosticsEngine: diags)
       _ = try driver.planBuild()
-      XCTAssertTrue(diags.diagnostics.first!.message.text == Diagnostic.Message.error_no_objc_interop_embedded.text)
+      XCTAssertEqual(diags.diagnostics.first!.message.text, Diagnostic.Message.error_no_objc_interop_embedded.text)
     } catch _ { }
   }
 
@@ -7040,7 +7044,7 @@ final class SwiftDriverTests: XCTestCase {
       args: ["swiftc", "-help"],
       env: env)
     let jobs = try driver.planBuild()
-    XCTAssert(jobs.count == 1)
+    XCTAssertEqual(jobs.count, 1)
     XCTAssertEqual(jobs.first!.tool.name, swiftHelp.pathString)
   }
 
@@ -7568,7 +7572,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTFail("FileList wasn't List")
         return
       }
-      XCTAssertTrue(outputs.count == 3)
+      XCTAssertEqual(outputs.count, 3)
       XCTAssertTrue(matchTemporary(outputs[0], "a.bc"))
       XCTAssertTrue(matchTemporary(outputs[1], "b.bc"))
       XCTAssertTrue(matchTemporary(outputs[2], "c.bc"))
@@ -7589,7 +7593,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTFail("FileList wasn't List")
         return
       }
-      XCTAssertTrue(inputs.count == 3)
+      XCTAssertEqual(inputs.count, 3)
       XCTAssertTrue(matchTemporary(inputs[0], "a.o"))
       XCTAssertTrue(matchTemporary(inputs[1], "b.o"))
       XCTAssertTrue(matchTemporary(inputs[2], "c.o"))
@@ -7610,7 +7614,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTFail("FileList wasn't List")
         return
       }
-      XCTAssertTrue(inputs.count == 3)
+      XCTAssertEqual(inputs.count, 3)
       XCTAssertTrue(matchTemporary(inputs[0], "a.o"))
       XCTAssertTrue(matchTemporary(inputs[1], "b.o"))
       XCTAssertTrue(matchTemporary(inputs[2], "c.o"))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1759,9 +1759,9 @@ final class SwiftDriverTests: XCTestCase {
   }
     
   func testResponseFileDeterministicNaming() throws {
-    #if !os(macOS)
-    throw XCTSkip("Test assumes macOS response file quoting behavior")
-    #endif
+#if !os(macOS)
+    try XCTSkipIf(true, "Test assumes macOS response file quoting behavior")
+#endif
     do {
       let testJob = Job(moduleName: "Foo",
                         kind: .compile,
@@ -3113,7 +3113,7 @@ final class SwiftDriverTests: XCTestCase {
 
   func testEmitABIDescriptor() throws {
 #if !os(macOS)
-    throw XCTSkip("Skipping: ABI descriptor is only emitted on Darwin platforms.")
+    try XCTSkipIf(true, "Skipping: ABI descriptor is only emitted on Darwin platforms.")
 #endif
     do {
       var driver = try Driver(args: ["swiftc", "-module-name=ThisModule", "-wmo", "main.swift", "multi-threaded.swift", "-emit-module", "-o", "test.swiftmodule"])
@@ -3142,7 +3142,6 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(plannedJobs[2].kind, .mergeModule)
       XCTAssertJobInvocationMatches(plannedJobs[2], .flag("-emit-abi-descriptor-path"))
     }
-
   }
 
   func testWMOWithNonSourceInput() throws {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6230,7 +6230,7 @@ final class SwiftDriverTests: XCTestCase {
       try testInputsPath.appending(component: "testLoadPackageInterface")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc", main.nativePathString(escaped: true),
-                                     "-typecheck", "-v",
+                                     "-typecheck",
                                      "-package-name", "foopkg",
                                      "-experimental-package-interface-load",
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
@@ -6927,7 +6927,6 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: [
         "swiftc",
-        "-v",
         "-L",
         "/TestApp/.build/aarch64-none-none-elf/release",
         "-o",

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7517,24 +7517,20 @@ final class SwiftDriverTests: XCTestCase {
       let inputsFlag = job.commandLine.firstIndex(of: .flag("-filelist"))!
       let inputFileListArgument = job.commandLine[job.commandLine.index(after: inputsFlag)]
       guard case let .path(.fileList(_, inputFileList)) = inputFileListArgument else {
-        XCTFail("Argument wasn't a filelist")
-        return
+        return XCTFail("Argument wasn't a filelist")
       }
       guard case let .list(inputs) = inputFileList else {
-        XCTFail("FileList wasn't List")
-        return
+        return XCTFail("FileList wasn't List")
       }
       XCTAssertEqual(inputs, [try toPath("a.swift"), try toPath("b.swift"), try toPath("c.swift")])
 
       let outputsFlag = job.commandLine.firstIndex(of: .flag("-output-filelist"))!
       let outputFileListArgument = job.commandLine[job.commandLine.index(after: outputsFlag)]
       guard case let .path(.fileList(_, outputFileList)) = outputFileListArgument else {
-        XCTFail("Argument wasn't a filelist")
-        return
+        return XCTFail("Argument wasn't a filelist")
       }
       guard case let .list(outputs) = outputFileList else {
-        XCTFail("FileList wasn't List")
-        return
+        return XCTFail("FileList wasn't List")
       }
       XCTAssertEqual(outputs, [try toPath("main.o")])
     }
@@ -7547,12 +7543,10 @@ final class SwiftDriverTests: XCTestCase {
       let outputsFlag = job.commandLine.firstIndex(of: .flag("-output-filelist"))!
       let outputFileListArgument = job.commandLine[job.commandLine.index(after: outputsFlag)]
       guard case let .path(.fileList(_, outputFileList)) = outputFileListArgument else {
-        XCTFail("Argument wasn't a filelist")
-        return
+        return XCTFail("Argument wasn't a filelist")
       }
       guard case let .list(outputs) = outputFileList else {
-        XCTFail("FileList wasn't List")
-        return
+        return XCTFail("FileList wasn't List")
       }
       XCTAssertEqual(outputs, [try toPath("a.o"), try toPath("b.o"), try toPath("c.o")])
     }
@@ -7565,12 +7559,10 @@ final class SwiftDriverTests: XCTestCase {
       let outputsFlag = job.commandLine.firstIndex(of: .flag("-output-filelist"))!
       let outputFileListArgument = job.commandLine[job.commandLine.index(after: outputsFlag)]
       guard case let .path(.fileList(_, outputFileList)) = outputFileListArgument else {
-        XCTFail("Argument wasn't a filelist")
-        return
+        return XCTFail("Argument wasn't a filelist")
       }
       guard case let .list(outputs) = outputFileList else {
-        XCTFail("FileList wasn't List")
-        return
+        return XCTFail("FileList wasn't List")
       }
       XCTAssertEqual(outputs.count, 3)
       XCTAssertTrue(matchTemporary(outputs[0], "a.bc"))
@@ -7586,12 +7578,10 @@ final class SwiftDriverTests: XCTestCase {
       let inputsFlag = job.commandLine.firstIndex(of: .flag("-filelist"))!
       let inputFileListArgument = job.commandLine[job.commandLine.index(after: inputsFlag)]
       guard case let .path(.fileList(_, inputFileList)) = inputFileListArgument else {
-        XCTFail("Argument wasn't a filelist")
-        return
+        return XCTFail("Argument wasn't a filelist")
       }
       guard case let .list(inputs) = inputFileList else {
-        XCTFail("FileList wasn't List")
-        return
+        return XCTFail("FileList wasn't List")
       }
       XCTAssertEqual(inputs.count, 3)
       XCTAssertTrue(matchTemporary(inputs[0], "a.o"))
@@ -7607,12 +7597,10 @@ final class SwiftDriverTests: XCTestCase {
       let inputsFlag = job.commandLine.firstIndex(of: .flag("-filelist"))!
       let inputFileListArgument = job.commandLine[job.commandLine.index(after: inputsFlag)]
       guard case let .path(.fileList(_, inputFileList)) = inputFileListArgument else {
-        XCTFail("Argument wasn't a filelist")
-        return
+        return XCTFail("Argument wasn't a filelist")
       }
       guard case let .list(inputs) = inputFileList else {
-        XCTFail("FileList wasn't List")
-        return
+        return XCTFail("FileList wasn't List")
       }
       XCTAssertEqual(inputs.count, 3)
       XCTAssertTrue(matchTemporary(inputs[0], "a.o"))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -269,7 +269,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       let helpJob = plannedJobs.first!
-      XCTAssertTrue(helpJob.kind == .help)
+      XCTAssertEqual(helpJob.kind, .help)
       XCTAssertTrue(helpJob.requiresInPlaceExecution)
       XCTAssertTrue(helpJob.tool.name.hasSuffix("swift-help"))
       let expected: [Job.ArgTemplate] = [.flag("swift")]
@@ -281,7 +281,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       XCTAssertEqual(plannedJobs.count, 1)
       let helpJob = plannedJobs.first!
-      XCTAssertTrue(helpJob.kind == .help)
+      XCTAssertEqual(helpJob.kind, .help)
       XCTAssertTrue(helpJob.requiresInPlaceExecution)
       XCTAssertTrue(helpJob.tool.name.hasSuffix("swift-help"))
       let expected: [Job.ArgTemplate] = [.flag("swiftc"), .flag("-show-hidden")]
@@ -930,9 +930,9 @@ final class SwiftDriverTests: XCTestCase {
                                        "-emit-library", "-module-name", "Test", "-serialize-diagnostics"])
         let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
         XCTAssertEqual(plannedJobs.count, 3)
-        XCTAssertTrue(plannedJobs[0].kind == .emitModule)
-        XCTAssertTrue(plannedJobs[1].kind == .compile)
-        XCTAssertTrue(plannedJobs[2].kind == .link)
+        XCTAssertEqual(plannedJobs[0].kind, .emitModule)
+        XCTAssertEqual(plannedJobs[1].kind, .compile)
+        XCTAssertEqual(plannedJobs[2].kind, .link)
         try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-serialize-diagnostics-path"), .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia"))))
         try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-serialize-diagnostics-path"), .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.dia"))))
       }
@@ -944,9 +944,9 @@ final class SwiftDriverTests: XCTestCase {
                                        "-emit-library", "-module-name", "Test", "-serialize-diagnostics"])
         let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
         XCTAssertEqual(plannedJobs.count, 3)
-        XCTAssertTrue(plannedJobs[0].kind == .compile)
-        XCTAssertTrue(plannedJobs[1].kind == .emitModule)
-        XCTAssertTrue(plannedJobs[2].kind == .link)
+        XCTAssertEqual(plannedJobs[0].kind, .compile)
+        XCTAssertEqual(plannedJobs[1].kind, .emitModule)
+        XCTAssertEqual(plannedJobs[2].kind, .link)
         try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-serialize-diagnostics-path"), .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia"))))
         try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-serialize-diagnostics-path"), .path(.absolute(.init(validating: "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia"))))
       }
@@ -1776,7 +1776,7 @@ final class SwiftDriverTests: XCTestCase {
                         outputs: [])
       let resolver = try ArgsResolver(fileSystem: localFileSystem)
       let resolvedArgs: [String] = try resolver.resolveArgumentList(for: testJob)
-      XCTAssertTrue(resolvedArgs.count == 3)
+      XCTAssertEqual(resolvedArgs.count, 3)
       XCTAssertEqual(resolvedArgs[2].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
       XCTAssertEqual(responseFilePath.basename, "arguments-847d15e70d97df7c18033735497ca8dcc4441f461d5a9c2b764b127004524e81.resp")
@@ -5428,7 +5428,7 @@ final class SwiftDriverTests: XCTestCase {
     for arg in ["-version", "--version"] {
       var driver = try Driver(args: ["swift"] + [arg])
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertEqual(job.kind, .versionRequest)
       XCTAssertEqual(job.commandLine, [.flag("--version")])
@@ -5461,7 +5461,7 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "arm64-apple-ios12.0", "-sdk", "bar", "-resource-dir", "baz"])
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       let job = plannedJobs[0]
       XCTAssertEqual(job.kind, .printTargetInfo)
       XCTAssertJobInvocationMatches(job, .flag("-print-target-info"))
@@ -6175,12 +6175,12 @@ final class SwiftDriverTests: XCTestCase {
         let verifyJob = try plannedJobs.findJob(.verifyModuleInterface)
         let packageOutputs = emitJob.outputs.filter { $0.type == .packageSwiftInterface }
         let publicOutputs = emitJob.outputs.filter { $0.type == .swiftInterface }
-        XCTAssertTrue(packageOutputs.count == 1,
-                      "There should be one package swiftinterface output")
-        XCTAssertTrue(publicOutputs.count == 1,
-                      "There should be one public swiftinterface output")
-        XCTAssertTrue(verifyJob.inputs.count == 1)
-        XCTAssertTrue(verifyJob.inputs[0] == publicOutputs[0])
+        XCTAssertEqual(packageOutputs.count, 1,
+                       "There should be one package swiftinterface output")
+        XCTAssertEqual(publicOutputs.count, 1,
+                       "There should be one public swiftinterface output")
+        XCTAssertEqual(verifyJob.inputs.count, 1)
+        XCTAssertEqual(verifyJob.inputs[0], publicOutputs[0])
         XCTAssertTrue(verifyJob.outputs.isEmpty)
       }
 
@@ -6212,12 +6212,12 @@ final class SwiftDriverTests: XCTestCase {
         let verifyJob = try plannedJobs.findJob(.verifyModuleInterface)
         let packageOutputs = emitJob.outputs.filter { $0.type == .packageSwiftInterface }
         let publicOutputs = emitJob.outputs.filter { $0.type == .swiftInterface }
-        XCTAssertTrue(packageOutputs.count == 1,
-                      "There should be one package swiftinterface output")
-        XCTAssertTrue(publicOutputs.count == 1,
-                      "There should be one public swiftinterface output")
-        XCTAssertTrue(verifyJob.inputs.count == 1)
-        XCTAssertTrue(verifyJob.inputs[0] == publicOutputs[0])
+        XCTAssertEqual(packageOutputs.count, 1,
+                       "There should be one package swiftinterface output")
+        XCTAssertEqual(publicOutputs.count, 1,
+                       "There should be one public swiftinterface output")
+        XCTAssertEqual(verifyJob.inputs.count, 1)
+        XCTAssertEqual(verifyJob.inputs[0], publicOutputs[0])
         XCTAssertTrue(verifyJob.outputs.isEmpty)
       }
   }
@@ -6241,7 +6241,7 @@ final class SwiftDriverTests: XCTestCase {
                               env: envVars)
 
       let plannedJobs = try driver.planBuild()
-      XCTAssertTrue(plannedJobs.count == 1)
+      XCTAssertEqual(plannedJobs.count, 1)
       XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-experimental-package-interface-load"))
     }
   }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -7675,8 +7675,7 @@ final class SwiftDriverTests: XCTestCase {
                                        "-c",
                                        "-incremental",
                                        "-output-file-map", ofm.nativePathString(escaped: true),
-                                       main.nativePathString(escaped: true)] + sdkArguments,
-                                env: ProcessEnv.vars)
+                                       main.nativePathString(escaped: true)] + sdkArguments)
         let jobs = try driver.planBuild()
         do {try driver.run(jobs: jobs)}
         catch {return false}

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1761,7 +1761,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(resolvedArgs.contains { $0.hasPrefix("@") })
     }
   }
-    
+
   func testResponseFileDeterministicNaming() throws {
 #if !os(macOS)
     try XCTSkipIf(true, "Test assumes macOS response file quoting behavior")
@@ -6926,7 +6926,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertJobInvocationMatches(compileJob, .flag("-disable-objc-interop"))
       XCTAssertFalse(linkJob.commandLine.contains(.flag("-force_load")))
     }
-    
+
     do {
       var driver = try Driver(args: [
         "swiftc",
@@ -6951,7 +6951,7 @@ final class SwiftDriverTests: XCTestCase {
         "-tools-directory",
         "/Tools/swift.xctoolchain/usr/bin",
       ], env: env)
-      
+
       let jobs = try driver.planBuild()
       let linkJob = try jobs.findJob(.link)
       let invalidPath = try VirtualPath(path: "/Tools/swift.xctoolchain/usr/lib/swift")
@@ -6959,7 +6959,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(invalid) // ensure the driver does not emit invalid responseFilePaths to the clang invocation
       XCTAssertFalse(linkJob.commandLine.joinedUnresolvedArguments.contains("swiftrt.o"))
     }
-    
+
     // Embedded Wasm compile job
     do {
       var driver = try Driver(args: ["swiftc", "-target", "wasm32-none-none-wasm", "test.swift", "-enable-experimental-feature", "Embedded", "-wmo", "-o", "a.wasm"], env: env)
@@ -7251,7 +7251,7 @@ final class SwiftDriverTests: XCTestCase {
       })
     }
   }
-  
+
   func testRelativeInputs() throws {
     do {
       // Inputs with relative paths with no -working-directory flag should remain relative
@@ -7283,7 +7283,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-resource-dir", try toPathOption("/foo/bar/relresourcepath", isRelative: false)]))
       XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-sdk", try toPathOption("/foo/bar/relsdkpath", isRelative: false)]))
     }
-    
+
     try withTemporaryFile { fileMapFile in
       let outputMapContents: ByteString = """
       {
@@ -7297,7 +7297,7 @@ final class SwiftDriverTests: XCTestCase {
       }
       """
       try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
-      
+
       // Inputs with relative paths should be found in output file maps
       var driver = try Driver(args: ["swiftc",
                                      "-target", "arm64-apple-ios13.1",
@@ -7308,7 +7308,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(compileJob.kind, .compile)
       XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-o", try toPathOption("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o", isRelative: false)]))
     }
-    
+
     try withTemporaryFile { fileMapFile in
       let outputMapContents: ByteString = """
       {
@@ -7322,7 +7322,7 @@ final class SwiftDriverTests: XCTestCase {
       }
       """
       try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
-      
+
       // Inputs with relative paths and working-dir should use absolute paths in output file maps
       var driver = try Driver(args: ["swiftc",
                                      "-target", "arm64-apple-ios13.1",


### PR DESCRIPTION
Another round of cleanups in the test suite to help ease diagnostics.

- Reduce verbosity in the driver execution
- Prefer `XCTSkipIf` to avoid warnings about unexecuted code
- Silence mutation related warning
- Remove defaulted argument in `Driver` construction to avoid deprecation warnings
- Prefer `XCTAssertEqual` over `XCTAssert` and `XCTAssertTrue` of equality expressions
- Cleanup some bleeding whitespace
- Compress multiline statements returning `()` to single line