### PR TITLE
Jobs: adjust swift module wrapping job (NFC)

### DIFF
--- a/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
+++ b/Sources/SwiftDriver/Jobs/ModuleWrapJob.swift
@@ -18,7 +18,6 @@ extension Driver {
 
     // Add the input.
     commandLine.append(.path(moduleInput.file))
-    assert(compilerOutputType == .object, "-modulewrap mode only produces object files")
 
     commandLine.appendFlags("-target", targetTriple.triple)
 

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -674,21 +674,20 @@ extension Driver {
                                                  addJob: (Job) -> Void,
                                                  addLinkerInput: (TypedVirtualPath) -> Void)
   throws {
-    guard case .astTypes = debugInfo.level
-    else { return }
-    if targetTriple.objectFormat != .macho {
+    guard case .astTypes = debugInfo.level else { return }
+
+    let mergeModuleOutputs = mergeJob.outputs.filter { $0.type == .swiftModule }
+    assert(mergeModuleOutputs.count == 1,
+            "Merge module job should only have one swiftmodule output")
+
+    if targetTriple.objectFormat == .macho {
+      addLinkerInput(mergeModuleOutputs[0])
+    } else {
       // Module wrapping is required.
-      let mergeModuleOutputs = mergeJob.outputs.filter { $0.type == .swiftModule }
-      assert(mergeModuleOutputs.count == 1,
-             "Merge module job should only have one swiftmodule output")
       let wrapJob = try moduleWrapJob(moduleInput: mergeModuleOutputs[0])
       addJob(wrapJob)
+
       wrapJob.outputs.forEach(addLinkerInput)
-    } else {
-      let mergeModuleOutputs = mergeJob.outputs.filter { $0.type == .swiftModule }
-      assert(mergeModuleOutputs.count == 1,
-             "Merge module job should only have one swiftmodule output")
-      addLinkerInput(mergeModuleOutputs[0])
     }
   }
 


### PR DESCRIPTION
With `-emit-module`, the output type computed is the swiftmodule. This output is subsequently wrapped by the module wrap job which will embed the swift module into an object file. This would trigger the assertion previously. Clean up some of the planning code associated with this in tandem.