### PR TITLE
SwiftDriver: honour `SWIFT_DRIVER_SWIFTSCAN_LIB` on Windows

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -255,6 +255,10 @@ extension Toolchain {
   /// looks in the `lib` relative to the compiler executable.
   /// TODO: If the driver needs to lookup other shared libraries, this is simple to generalize
   @_spi(Testing) public func lookupSwiftScanLib() throws -> AbsolutePath? {
+    if let overrideString = env["SWIFT_DRIVER_SWIFTSCAN_LIB"],
+       let path = try? AbsolutePath(validating: overrideString) {
+      return path
+    }
 #if os(Windows)
     // no matter if we are in a build tree or an installed tree, the layout is
     // always: `bin/_InternalSwiftScan.dll`
@@ -262,27 +266,22 @@ extension Toolchain {
                                           .appending(component: "_InternalSwiftScan.dll")
 #else
     let libraryName = sharedLibraryName("lib_InternalSwiftScan")
-    if let overrideString = env["SWIFT_DRIVER_SWIFTSCAN_LIB"],
-       let path = try? AbsolutePath(validating: overrideString) {
-      return path
-    } else {
-      let compilerPath = try getToolPath(.swiftCompiler)
-      let toolchainRootPath = compilerPath.parentDirectory // bin
-                                          .parentDirectory // toolchain root
+    let compilerPath = try getToolPath(.swiftCompiler)
+    let toolchainRootPath = compilerPath.parentDirectory // bin
+                                        .parentDirectory // toolchain root
 
-      let searchPaths = [toolchainRootPath.appending(component: "lib")
-                                          .appending(component: "swift")
-                                          .appending(component: compilerHostSupportLibraryOSComponent),
-                         toolchainRootPath.appending(component: "lib")
-                                          .appending(component: "swift")
-                                          .appending(component: "host"),
-                         // In case we are using a compiler from the build dir, we should also try
-                         // this path.
-                         toolchainRootPath.appending(component: "lib")]
-      for libraryPath in searchPaths.map({ $0.appending(component: libraryName) }) {
-        if fileSystem.isFile(libraryPath) {
-          return libraryPath
-        }
+    let searchPaths = [toolchainRootPath.appending(component: "lib")
+                                        .appending(component: "swift")
+                                        .appending(component: compilerHostSupportLibraryOSComponent),
+                        toolchainRootPath.appending(component: "lib")
+                                        .appending(component: "swift")
+                                        .appending(component: "host"),
+                        // In case we are using a compiler from the build dir, we should also try
+                        // this path.
+                        toolchainRootPath.appending(component: "lib")]
+    for libraryPath in searchPaths.map({ $0.appending(component: libraryName) }) {
+      if fileSystem.isFile(libraryPath) {
+        return libraryPath
       }
     }
 


### PR DESCRIPTION
We would previously not honour this flag on Windows as the layout of the toolchain is different on Windows from the other platforms. The computed path needing to be different bifurcated the implementation. Hoist a path for override handling into the shared path.