### PR TITLE
Tests: remove some invalid tests

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5447,14 +5447,6 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
     do {
-      var driver = try Driver(args: ["swiftc", "-v"])
-      XCTAssertNoThrow(try driver.planBuild())
-    }
-    do {
-      var driver = try Driver(args: ["swiftc", "-v", "-whole-module-optimization"])
-      XCTAssertNoThrow(try driver.planBuild())
-    }
-    do {
       var driver = try Driver(args: ["swiftc", "-whole-module-optimization"])
       XCTAssertThrowsError(try driver.planBuild()) {
         XCTAssertEqual($0 as? Driver.Error, .noInputFiles)


### PR DESCRIPTION
Invoking `swiftc` without any inputs is expected to fail (as is being tested by this test case!). Remove the invalid cases which were likely added for debugging.