### PR TITLE
Emit supplemental outputs for the target variant

### DIFF
--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -72,7 +72,7 @@ extension Driver {
       case .api:
         return nil
       case .abi:
-        return abiDescriptorPath
+        return moduleOutputPaths.abiDescriptorFilePath
       }
     }
     guard let currentABI = getDescriptorPath(for: mode) else {

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -277,6 +277,8 @@ extension Driver {
       primaryInputs: primaryInputs,
       inputsGeneratingCodeCount: inputsGeneratingCodeCount,
       inputOutputMap: &inputOutputMap,
+      moduleOutputInfo: self.moduleOutputInfo,
+      moduleOutputPaths: self.moduleOutputPaths,
       includeModuleTracePath: emitModuleTrace,
       indexFilePath: indexFilePath)
 

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -38,7 +38,7 @@ extension Driver {
     }
     addSupplementalOutput(path: objcGeneratedHeaderPath, flag: "-emit-objc-header-path", type: .objcHeader)
     addSupplementalOutput(path: tbdPath, flag: "-emit-tbd-path", type: .tbd)
-    addSupplementalOutput(path: apiDescriptorFilePath, flag: "-emit-api-descriptor-path", type: .jsonAPIDescriptor)
+    addSupplementalOutput(path: moduleOutputPaths.apiDescriptorFilePath, flag: "-emit-api-descriptor-path", type: .jsonAPIDescriptor)
 
     if isMergeModule {
       return

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -125,7 +125,7 @@ extension Driver {
     let outputPath = VirtualPath.lookup(moduleOutputPath)
     commandLine.appendFlag(.o)
     commandLine.appendPath(outputPath)
-    if let abiPath = abiDescriptorPath {
+    if let abiPath = moduleOutputPaths.abiDescriptorFilePath {
       commandLine.appendFlag(.emitAbiDescriptorPath)
       commandLine.appendPath(abiPath.file)
       outputs.append(abiPath)

--- a/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/EmitModuleJob.swift
@@ -17,6 +17,7 @@ extension Driver {
   mutating func addCommonModuleOptions(
       commandLine: inout [Job.ArgTemplate],
       outputs: inout [TypedVirtualPath],
+      moduleOutputPaths: SupplementalModuleTargetOutputPaths,
       isMergeModule: Bool
   ) throws {
     // Add supplemental outputs.
@@ -28,12 +29,12 @@ extension Driver {
       outputs.append(.init(file: path, type: type))
     }
 
-    addSupplementalOutput(path: moduleDocOutputPath, flag: "-emit-module-doc-path", type: .swiftDocumentation)
-    addSupplementalOutput(path: moduleSourceInfoPath, flag: "-emit-module-source-info-path", type: .swiftSourceInfoFile)
-    addSupplementalOutput(path: swiftInterfacePath, flag: "-emit-module-interface-path", type: .swiftInterface)
-    addSupplementalOutput(path: swiftPrivateInterfacePath, flag: "-emit-private-module-interface-path", type: .privateSwiftInterface)
+    addSupplementalOutput(path: moduleOutputPaths.moduleDocOutputPath, flag: "-emit-module-doc-path", type: .swiftDocumentation)
+    addSupplementalOutput(path: moduleOutputPaths.moduleSourceInfoPath, flag: "-emit-module-source-info-path", type: .swiftSourceInfoFile)
+    addSupplementalOutput(path: moduleOutputPaths.swiftInterfacePath, flag: "-emit-module-interface-path", type: .swiftInterface)
+    addSupplementalOutput(path: moduleOutputPaths.swiftPrivateInterfacePath, flag: "-emit-private-module-interface-path", type: .privateSwiftInterface)
     if let pkgName = packageName, !pkgName.isEmpty {
-      addSupplementalOutput(path: swiftPackageInterfacePath, flag: "-emit-package-module-interface-path", type: .packageSwiftInterface)
+      addSupplementalOutput(path: moduleOutputPaths.swiftPackageInterfacePath, flag: "-emit-package-module-interface-path", type: .packageSwiftInterface)
     }
     addSupplementalOutput(path: objcGeneratedHeaderPath, flag: "-emit-objc-header-path", type: .objcHeader)
     addSupplementalOutput(path: tbdPath, flag: "-emit-tbd-path", type: .tbd)
@@ -102,7 +103,7 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .emitModule)
     // FIXME: Add MSVC runtime library flags
 
-    try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: false)
+    try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, moduleOutputPaths: moduleOutputPaths,isMergeModule: false)
     try addCommonSymbolGraphOptions(commandLine: &commandLine)
 
     try commandLine.appendLast(.checkApiAvailabilityOnly, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -706,7 +706,7 @@ extension Driver {
 
         try addOutputOfType(
           outputType: .jsonAPIDescriptor,
-          finalOutputPath: apiDescriptorFilePath,
+          finalOutputPath: moduleOutputPaths.apiDescriptorFilePath,
           input: nil,
           flag: "-emit-api-descriptor-path")
       }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -697,7 +697,7 @@ extension Driver {
           input: nil,
           flag: "-emit-tbd-path")
 
-        if let abiDescriptorPath = abiDescriptorPath {
+        if let abiDescriptorPath = moduleOutputPaths.abiDescriptorFilePath {
           try addOutputOfType(outputType: .jsonABIBaseline,
                           finalOutputPath: abiDescriptorPath.fileHandle,
                           input: nil,

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -57,7 +57,7 @@ extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .mergeModule, bridgingHeaderHandling: .parsed)
     // FIXME: Add MSVC runtime library flags
 
-    try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, isMergeModule: true)
+    try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, moduleOutputPaths: moduleOutputPaths, isMergeModule: true)
 
     try addCommonSymbolGraphOptions(commandLine: &commandLine)
 

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -65,7 +65,7 @@ extension Driver {
     commandLine.appendFlag(.o)
     commandLine.appendPath(outputPath)
 
-    if let abiPath = abiDescriptorPath {
+    if let abiPath = moduleOutputPaths.abiDescriptorFilePath {
       commandLine.appendFlag(.emitAbiDescriptorPath)
       commandLine.appendPath(abiPath.file)
       outputs.append(abiPath)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -384,6 +384,7 @@ extension Option {
   public static let emitTbdPathEQ: Option = Option("-emit-tbd-path=", .joined, alias: Option.emitTbdPath, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant])
   public static let emitTbdPath: Option = Option("-emit-tbd-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Emit the TBD file to <path>")
   public static let emitTbd: Option = Option("-emit-tbd", .flag, attributes: [.frontend, .noInteractive, .supplementaryOutput], helpText: "Emit a TBD file")
+  public static let emitVariantAbiDescriptorPath: Option = Option("-emit-variant-abi-descriptor-path", .separate, attributes: [.frontend, .noDriver, .cacheInvariant], metaVar: "<path>", helpText: "Output the ABI descriptor of current target variant module to <path>")
   public static let emitVariantApiDescriptorPath: Option = Option("-emit-variant-api-descriptor-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output a JSON file describing the target variant module's API to <path>")
   public static let emitVariantModuleDocPath: Option = Option("-emit-variant-module-doc-path", .separate, attributes: [.frontend, .noDriver, .cacheInvariant], metaVar: "<path>", helpText: "Output module documentation file for the target variant to <path>")
   public static let emitVariantModuleInterfacePath: Option = Option("-emit-variant-module-interface-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output module interface file for the target variant to <path>")
@@ -1304,6 +1305,7 @@ extension Option {
       Option.emitTbdPathEQ,
       Option.emitTbdPath,
       Option.emitTbd,
+      Option.emitVariantAbiDescriptorPath,
       Option.emitVariantApiDescriptorPath,
       Option.emitVariantModuleDocPath,
       Option.emitVariantModuleInterfacePath,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -384,6 +384,13 @@ extension Option {
   public static let emitTbdPathEQ: Option = Option("-emit-tbd-path=", .joined, alias: Option.emitTbdPath, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant])
   public static let emitTbdPath: Option = Option("-emit-tbd-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Emit the TBD file to <path>")
   public static let emitTbd: Option = Option("-emit-tbd", .flag, attributes: [.frontend, .noInteractive, .supplementaryOutput], helpText: "Emit a TBD file")
+  public static let emitVariantApiDescriptorPath: Option = Option("-emit-variant-api-descriptor-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output a JSON file describing the target variant module's API to <path>")
+  public static let emitVariantModuleDocPath: Option = Option("-emit-variant-module-doc-path", .separate, attributes: [.frontend, .noDriver, .cacheInvariant], metaVar: "<path>", helpText: "Output module documentation file for the target variant to <path>")
+  public static let emitVariantModuleInterfacePath: Option = Option("-emit-variant-module-interface-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output module interface file for the target variant to <path>")
+  public static let emitVariantModulePath: Option = Option("-emit-variant-module-path", .separate, attributes: [.noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Emit an importable module for the target variant at the specified path")
+  public static let emitVariantModuleSourceInfoPath: Option = Option("-emit-variant-module-source-info-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput], metaVar: "<path>", helpText: "Output module source info file for the target variant to <path>")
+  public static let emitVariantPackageModuleInterfacePath: Option = Option("-emit-variant-package-module-interface-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output package module interface file for the target variant to <path>")
+  public static let emitVariantPrivateModuleInterfacePath: Option = Option("-emit-variant-private-module-interface-path", .separate, attributes: [.frontend, .noInteractive, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<path>", helpText: "Output private module interface file for the target variant to <path>")
   public static let emitVerboseSil: Option = Option("-emit-verbose-sil", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Emit locations during SIL emission")
   public static let emptyAbiDescriptor: Option = Option("-empty-abi-descriptor", .flag, attributes: [.frontend, .noDriver], helpText: "Avoid printing actual module content into ABI descriptor file")
   public static let emptyBaseline: Option = Option("-empty-baseline", .flag, attributes: [.noDriver], helpText: "Use empty baseline for diagnostics")
@@ -926,10 +933,6 @@ extension Option {
   public static let Xlinker: Option = Option("-Xlinker", .separate, attributes: [.doesNotAffectIncrementalBuild], helpText: "Specifies an option which should be passed to the linker")
   public static let Xllvm: Option = Option("-Xllvm", .separate, attributes: [.helpHidden, .frontend], metaVar: "<arg>", helpText: "Pass <arg> to LLVM.")
   public static let DASHDASH: Option = Option("--", .remaining, attributes: [.frontend, .doesNotAffectIncrementalBuild])
-
-  public static let emitVariantModulePath: Option = Option("-emit-variant-module-path", .separate, attributes: [.noInteractive, .supplementaryOutput, .argumentIsPath], helpText: "Emit an importable module for the target variant at the specified path")
-  public static let emitVariantModuleInterface: Option = Option("-emit-variant-module-interface", .flag, attributes: [.noInteractive, .supplementaryOutput], helpText: "Emit an importable module for the target variant")
-
 }
 
 extension Option {
@@ -1301,6 +1304,13 @@ extension Option {
       Option.emitTbdPathEQ,
       Option.emitTbdPath,
       Option.emitTbd,
+      Option.emitVariantApiDescriptorPath,
+      Option.emitVariantModuleDocPath,
+      Option.emitVariantModuleInterfacePath,
+      Option.emitVariantModulePath,
+      Option.emitVariantModuleSourceInfoPath,
+      Option.emitVariantPackageModuleInterfacePath,
+      Option.emitVariantPrivateModuleInterfacePath,
       Option.emitVerboseSil,
       Option.emptyAbiDescriptor,
       Option.emptyBaseline,
@@ -1843,8 +1853,6 @@ extension Option {
       Option.Xlinker,
       Option.Xllvm,
       Option.DASHDASH,
-      Option.emitVariantModulePath,
-      Option.emitVariantModuleInterface,
     ]
   }
 }

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -926,6 +926,10 @@ extension Option {
   public static let Xlinker: Option = Option("-Xlinker", .separate, attributes: [.doesNotAffectIncrementalBuild], helpText: "Specifies an option which should be passed to the linker")
   public static let Xllvm: Option = Option("-Xllvm", .separate, attributes: [.helpHidden, .frontend], metaVar: "<arg>", helpText: "Pass <arg> to LLVM.")
   public static let DASHDASH: Option = Option("--", .remaining, attributes: [.frontend, .doesNotAffectIncrementalBuild])
+
+  public static let emitVariantModulePath: Option = Option("-emit-variant-module-path", .separate, attributes: [.noInteractive, .supplementaryOutput, .argumentIsPath], helpText: "Emit an importable module for the target variant at the specified path")
+  public static let emitVariantModuleInterface: Option = Option("-emit-variant-module-interface", .flag, attributes: [.noInteractive, .supplementaryOutput], helpText: "Emit an importable module for the target variant")
+
 }
 
 extension Option {
@@ -1839,6 +1843,8 @@ extension Option {
       Option.Xlinker,
       Option.Xllvm,
       Option.DASHDASH,
+      Option.emitVariantModulePath,
+      Option.emitVariantModuleInterface,
     ]
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4147,6 +4147,32 @@ final class SwiftDriverTests: XCTestCase {
         ]))
       }
     }
+
+    do {
+      var driver = try Driver(args: ["swiftc",
+        "-target", "x86_64-apple-macosx10.14",
+        "-target-variant", "x86_64-apple-ios13.1-macabi",
+        "-emit-variant-module-path", "foo.swiftmodule/x86_64-apple-ios13.1-macabi.swiftmodule",
+        "-enable-library-evolution",
+        "-emit-module",
+        "-emit-api-descriptor-path", "foo.swiftmodule/target.api.json",
+        "-emit-variant-api-descriptor-path", "foo.swiftmodule/variant.api.json",
+        "foo.swift"])
+
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      let targetModuleJob = plannedJobs[0]
+      let variantModuleJob = plannedJobs[1]
+
+      XCTAssert(targetModuleJob.commandLine.contains(subsequence: [
+        .flag("-emit-api-descriptor-path"),
+        .path(.relative(try .init(validating: "foo.swiftmodule/target.api.json")))
+      ]))
+
+      XCTAssert(variantModuleJob.commandLine.contains(subsequence: [
+        .flag("-emit-api-descriptor-path"),
+        .path(.relative(try .init(validating: "foo.swiftmodule/variant.api.json")))
+      ]))
+    }
 #endif
   }
 


### PR DESCRIPTION
This patch teaches the driver how to emit the supplementary outputs for a module build for the target-variant.

These supplementary outputs are:
 - Swift module
 - Swift module documentation
 - Swift module source information
 - Swift interface
 - Swift private interface
 - Swift package interface
 - JSON API description
 - JSON ABI description

This means that the driver can emit all of the relevant outputs for a build in a single invocation without needing to be called twice with the same arguments, with one to emit the zippered object and target supplemental outputs, and again for the target-variant outputs.

Patch to add new flags: https://github.com/swiftlang/swift/pull/78336

rdar://141582282