### PR TITLE
libclang_rt.profile*.a search path should use osNameUnversioned

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -287,7 +287,7 @@ extension GenericUnixToolchain {
       if parsedOptions.hasArgument(.profileGenerate) {
         let environment = (targetTriple.environment == .android) ? "-android" : ""
         let libProfile = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-          .appending(components: "clang", "lib", targetTriple.osName,
+          .appending(components: "clang", "lib", targetTriple.osNameUnversioned,
                                  "libclang_rt.profile-\(targetTriple.archName)\(environment).a")
         commandLine.appendPath(libProfile)
 

--- a/Tests/SwiftDriverTests/TripleTests.swift
+++ b/Tests/SwiftDriverTests/TripleTests.swift
@@ -48,6 +48,12 @@ final class TripleTests: XCTestCase {
     XCTAssertEqual(Triple("arm64-apple-none-macho").os, .noneOS)
     XCTAssertEqual(Triple("arm64-apple-none-macho").environment, nil)
     XCTAssertEqual(Triple("arm64-apple-none-macho").objectFormat, .macho)
+
+    XCTAssertEqual(Triple("x86_64-unknown-freebsd14.1").arch, .x86_64)
+    XCTAssertEqual(Triple("x86_64-unknown-freebsd14.1").vendor, nil)
+    XCTAssertEqual(Triple("x86_64-unknown-freebsd14.1").os, .freeBSD)
+    XCTAssertEqual(Triple("x86_64-unknown-freebsd14.1").osNameUnversioned, "freebsd")
+    XCTAssertEqual(Triple("x86_64-unknown-freebsd14.1").objectFormat, .elf)
   }
 
   func testBasicParsing() {


### PR DESCRIPTION
On platforms where the triple includes the os version, in this case `x86_64-unknown-freebsd14.2`,
the swift-driver is trying to link against various clang rt libraries in `clang/lib/freebsd14.2`, but the actual
clang convention is to have the libraries installed in `clang/lib/freebsd` instead, see [clang/lib/Driver/ToolChain.cpp#L686](https://github.com/swiftlang/llvm-project/blob/985636ed916ef54e2df74f9d72fc20656b11c094/clang/lib/Driver/ToolChain.cpp#L686).

Although the right solution is probably to implement `getOSLibName` in `swift-driver`; we can just use
`osNameUnversioned` for now as the only special case where `getOSLibName != osNameUnversioned`
is for `Solaris`, which is not yet supported.
