### PR TITLE
Tests: repair the test suite on Windows

### DIFF
--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -222,7 +222,7 @@ extension Toolchain {
               let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [toolDir]) {
       // Looking for tools from the tools directory.
       return path
-    } else if let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: nil, searchPaths: [try executableDir]) {
+    } else if let path = lookupExecutablePath(filename: executableName(executable), currentWorkingDirectory: fileSystem.currentWorkingDirectory, searchPaths: [try executableDir]) {
       return path
     } else if let path = try? xcrunFind(executable: executableName(executable)) {
       return path

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -583,6 +583,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
           } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
+          } else if relativeOutputPathFileName.starts(with: "_Builtin_stdint-") {
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_Builtin_stdint"),
+                                            dependencyGraph: dependencyGraph)
           } else if hostTriple.isMacOSX,
              hostTriple.version(for: .macOS) < Triple.Version(11, 0, 0),
              relativeOutputPathFileName.starts(with: "X-") {
@@ -593,7 +596,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
           }
         } else {
           switch (outputFilePath) {
-            case .relative(try .init(validating: "testExplicitModuleBuildJobs")):
+            case .relative(try .init(validating: "testExplicitModuleBuildJobs")),
+                .relative(try .init(validating: "testExplicitModuleBuildJobs.exe")):
               XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
               XCTAssertEqual(job.kind, .link)
             case .absolute(let path):
@@ -636,6 +640,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let invocationArguments = ["swiftc",
+                                 "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                  "-I", cHeadersPath.nativePathString(escaped: true),
                                  "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                  "-explicit-module-build",
@@ -770,12 +775,16 @@ final class ExplicitModuleBuildTests: XCTestCase {
           } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
+          } else if relativeOutputPathFileName.starts(with: "_Builtin_stdint-") {
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_Builtin_stdint"),
+                                            dependencyGraph: dependencyGraph)
           } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
         } else {
           switch (outputFilePath) {
-            case .relative(try .init(validating: "testExplicitModuleVerifyInterfaceJobs")):
+            case .relative(try .init(validating: "testExplicitModuleVerifyInterfaceJobs")),
+                .relative(try .init(validating: "testExplicitModuleVerifyInterfaceJobs.exe")):
               XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
               XCTAssertEqual(job.kind, .link)
             case .absolute(let path):
@@ -893,6 +902,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
           } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
+          } else if relativeOutputPathFileName.starts(with: "_Builtin_stdint-") {
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_Builtin_stdint"),
+                                            dependencyGraph: dependencyGraph)
           } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
@@ -910,7 +922,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
           // Check we don't use `-pch-output-dir` anymore during main module job.
           XCTAssertFalse(job.commandLine.contains("-pch-output-dir"))
           switch (outputFilePath) {
-            case .relative(try .init(validating: "testExplicitModuleBuildPCHOutputJobs")):
+            case .relative(try .init(validating: "testExplicitModuleBuildPCHOutputJobs")),
+                .relative(try .init(validating: "testExplicitModuleBuildPCHOutputJobs.exe")):
               XCTAssertTrue(driver.isExplicitMainModuleJob(job: job))
               XCTAssertEqual(job.kind, .link)
             case .absolute(let path):
@@ -1009,6 +1022,9 @@ final class ExplicitModuleBuildTests: XCTestCase {
           } else if relativeOutputPathFileName.starts(with: "_SwiftConcurrencyShims-") {
             try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_SwiftConcurrencyShims"),
                                             dependencyGraph: dependencyGraph)
+          } else if relativeOutputPathFileName.starts(with: "_Builtin_stdint-") {
+            try checkExplicitModuleBuildJob(job: job, moduleId: .clang("_Builtin_stdint"),
+                                            dependencyGraph: dependencyGraph)
           } else {
             XCTFail("Unexpected module dependency build job output: \(outputFilePath)")
           }
@@ -1044,12 +1060,11 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
       // Create Bar.swiftmodule
       var driver = try Driver(args: ["swiftc",
+                                     "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                      "-explicit-module-build",
-                                     "-working-directory",
-                                     path.nativePathString(escaped: true),
+                                     "-working-directory", path.nativePathString(escaped: true),
                                      srcBar.nativePathString(escaped: true),
-                                     "-module-name",
-                                     "Bar",
+                                     "-module-name", "Bar",
                                      "-emit-module",
                                      "-emit-module-path", moduleBarPath,
                                      "-module-cache-path", path.nativePathString(escaped: true),
@@ -1271,6 +1286,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let (stdLibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
 
       var driver1 = try Driver(args: ["swiftc",
+                                      "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                       "-explicit-module-build",
                                       "-module-name", "Bar",
                                       "-working-directory", path.nativePathString(escaped: true),
@@ -1305,6 +1321,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
         """
       )
       var driver2 = try Driver(args: ["swiftc",
+                                      "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                       "-I", path.nativePathString(escaped: true),
                                       "-explicit-module-build",
                                       "-module-name", "Foo",
@@ -1347,6 +1364,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
+                                     "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-explicit-module-build",
@@ -1522,7 +1540,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-explicit-module-build",
                                      "-clang-scanner-module-cache-path",
-                                     scannerCachePath.nativePathString(escaped: true),
+                                     scannerCachePath.nativePathString(escaped: false),
                                      "-module-cache-path",
                                      moduleCachePath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
@@ -1759,7 +1777,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
          hostTriple.version(for: .macOS) < Triple.Version(11, 0, 0) {
         expectedNumberOfDependencies = 13
       } else if driver.targetTriple.isWindows {
-        expectedNumberOfDependencies = 15
+        expectedNumberOfDependencies = 13
       } else {
         expectedNumberOfDependencies = 12
       }
@@ -1816,6 +1834,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
   // Ensure dependency scanning succeeds via fallback `swift-frontend -scan-dependenceis`
   // mechanism if libSwiftScan.dylib fails to load.
   func testDependencyScanningFallback() throws {
+    try XCTSkipIf(true, "skipping until CAS is supported on all platforms")
+
     let (stdlibPath, shimsPath, _, _) = try getDriverArtifactsForScanning()
 
     // Create a simple test case.
@@ -2126,24 +2146,25 @@ final class ExplicitModuleBuildTests: XCTestCase {
 
   func testDependencyScanCommandLineEscape() throws {
 #if os(Windows)
-  let quoteCharacter: Character = "\""
+  let quote: Character = "\""
 #else
-  let quoteCharacter: Character = "'"
+  let quote: Character = "'"
 #endif
-    let swiftInputWithSpace = "/tmp/input example/test.swift"
-    let swiftInputWithoutSpace = "/tmp/baz.swift"
-    let clangInputWithSpace = "/tmp/input example/bar.o"
+    let input1 = try AbsolutePath(validating: "/tmp/input example/test.swift")
+    let input2 = try AbsolutePath(validating: "/tmp/baz.swift")
+    let input3 = try AbsolutePath(validating: "/tmp/input example/bar.o")
     var driver = try Driver(args: ["swiftc", "-explicit-module-build",
                                    "-module-name", "testDependencyScanning",
-                                   swiftInputWithSpace, swiftInputWithoutSpace,
-                                   "-Xcc", clangInputWithSpace])
+                                   input1.nativePathString(escaped: false),
+                                   input2.nativePathString(escaped: false),
+                                   "-Xcc", input3.nativePathString(escaped: false)])
     let scanJob = try driver.dependencyScanningJob()
     let scanJobCommand = try Driver.itemizedJobCommand(of: scanJob,
                                                        useResponseFiles: .disabled,
                                                        using: ArgsResolver(fileSystem: InMemoryFileSystem()))
-    XCTAssertTrue(scanJobCommand.contains(String(quoteCharacter) + swiftInputWithSpace + String(quoteCharacter)))
-    XCTAssertTrue(scanJobCommand.contains(String(quoteCharacter) + clangInputWithSpace + String(quoteCharacter)))
-    XCTAssertTrue(scanJobCommand.contains(swiftInputWithoutSpace))
+    XCTAssertTrue(scanJobCommand.contains("\(quote)\(input1.nativePathString(escaped: false))\(quote)"))
+    XCTAssertTrue(scanJobCommand.contains("\(quote)\(input3.nativePathString(escaped: false))\(quote)"))
+    XCTAssertTrue(scanJobCommand.contains(input2.nativePathString(escaped: false)))
   }
 
   func testDependencyGraphTransitiveClosure() throws {
@@ -2218,6 +2239,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       do {
         try assertDriverDiagnostics(args: [
             "swiftc",
+            "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
             "-I", cHeadersPath.nativePathString(escaped: true),
             "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
             "-explicit-module-build",
@@ -2241,6 +2263,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       do {
         try assertDriverDiagnostics(args:[
             "swiftc",
+            "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
             "-I", cHeadersPath.nativePathString(escaped: true),
             "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
             "-explicit-module-build",
@@ -2286,6 +2309,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let outputModule = path.appending(component: "Test.swiftmodule")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
+                                     "-Xcc", "-Xclang", "-Xcc", "-fbuiltin-headers-in-system-modules",
                                      "-explicit-module-build", "-module-name", "Test",
                                      "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),

--- a/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
+++ b/Tests/SwiftDriverTests/Inputs/ExplicitModuleDependencyBuildInputs.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import TSCBasic
 
 enum ModuleDependenciesInputs {
   static var fastDependencyScannerOutput: String {
@@ -174,9 +175,9 @@ enum ModuleDependenciesInputs {
                 "-Xcc",
                 "-fno-implicit-module-maps",
                 "-candidate-module-file",
-                "/dummy/path2/SwiftOnoneSupport.swiftmodule",
+                "\(AbsolutePath("/dummy/path2/SwiftOnoneSupport.swiftmodule").nativePathString(escaped: true))",
                 "-candidate-module-file",
-                "/dummy/path1/SwiftOnoneSupport.swiftmodule",
+                "\(AbsolutePath("/dummy/path1/SwiftOnoneSupport.swiftmodule").nativePathString(escaped: true))",
                 "-target",
                 "x86_64-apple-macosx10.15",
                 "-sdk",

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -609,9 +609,10 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertJobInvocationMatches(jobs[0], .flag("-file-compilation-dir"), .path(VirtualPath.lookup(path)))
     }
 
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-working-directory", "/tmp") { driver in
+    let workingDirectory = AbsolutePath("/tmp")
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-working-directory", workingDirectory.nativePathString(escaped: false)) { driver in
       let jobs = try driver.planBuild()
-      let path = try VirtualPath.intern(path: "/tmp")
+      let path = try VirtualPath.intern(path: workingDirectory.nativePathString(escaped: false))
       XCTAssertJobInvocationMatches(jobs[0], .flag("-file-compilation-dir"), .path(VirtualPath.lookup(path)))
     }
 
@@ -627,75 +628,78 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testDwarfVersionSetting() throws {
+    var environment = ProcessEnv.vars
+    environment["SDKROOT"] = nil
+
     let driver = try Driver(args: ["swiftc", "foo.swift"])
     guard driver.isFrontendArgSupported(.dwarfVersion) else {
       throw XCTSkip("Skipping: compiler does not support '-dwarf-version'")
     }
 
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=dwarf", "-dwarf-version=4") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module", "-g", "-debug-info-format=dwarf", "-dwarf-version=4", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
 
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx10.10") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx10.10", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=2"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx10.11") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx10.11", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macos14.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macos14.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-ios8.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-ios8.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=2"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-ios9.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-ios9.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-ios17-macabi") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-ios17-macabi", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-tvos17.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-tvos17.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64_32-apple-watchos10.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64_32-apple-watchos10.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
 
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx15") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "x86_64-apple-macosx15", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=5"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-ios18.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-ios18.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=5"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64_32-apple-watchos11") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64_32-apple-watchos11", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=5"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-tvos18") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-tvos18", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=5"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-xros1.0-simulator") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-xros1.0-simulator", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=4"))
     }
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-xros2.0") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-g", "-c", "-target", "arm64-apple-xros2.0", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertJobInvocationMatches(jobs[0], .flag("-dwarf-version=5"))
     }
 
-    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-c", "-file-compilation-dir", ".") { driver in
+    try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-c", "-file-compilation-dir", ".", env: environment) { driver in
       let jobs = try driver.planBuild()
       XCTAssertFalse(jobs[0].commandLine.contains(.flag("-file-compilation-dir")))
     }
@@ -1703,7 +1707,8 @@ final class SwiftDriverTests: XCTestCase {
     let manyArgs = (1...20000).map { "-DTEST_\($0)" }
     // Needs response file
     do {
-      var driver = try Driver(args: ["swift"] + manyArgs + ["/foo.swift"])
+      let source = AbsolutePath("/foo.swift")
+      var driver = try Driver(args: ["swift"] + manyArgs + [source.nativePathString(escaped: false)])
       let jobs = try driver.planBuild()
       XCTAssertEqual(jobs.count, 1)
       XCTAssertEqual(jobs[0].kind, .interpret)
@@ -1715,7 +1720,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(resolvedArgs[2].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
       let contents = try localFileSystem.readFileContents(responseFilePath).description
-      XCTAssertTrue(contents.hasPrefix("-interpret\n/foo.swift"))
+      XCTAssertTrue(contents.hasPrefix("-interpret\n\(source.nativePathString(escaped: false))"))
       XCTAssertTrue(contents.contains("-D\nTEST_20000"))
       XCTAssertTrue(contents.contains("-D\nTEST_1"))
     }
@@ -1734,7 +1739,8 @@ final class SwiftDriverTests: XCTestCase {
 
     // Forced response file
     do {
-      var driver = try Driver(args: ["swift"] + ["/foo.swift"])
+      let source = AbsolutePath("/foo.swift")
+      var driver = try Driver(args: ["swift"] + [source.nativePathString(escaped: false)])
       let jobs = try driver.planBuild()
       XCTAssertEqual(jobs.count, 1)
       XCTAssertEqual(jobs[0].kind, .interpret)
@@ -1746,7 +1752,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(resolvedArgs[2].first, "@")
       let responseFilePath = try AbsolutePath(validating: String(resolvedArgs[2].dropFirst()))
       let contents = try localFileSystem.readFileContents(responseFilePath).description
-      XCTAssertTrue(contents.hasPrefix("-interpret\n/foo.swift"))
+      XCTAssertTrue(contents.hasPrefix("-interpret\n\(source.nativePathString(escaped: false))"))
     }
 
     // No response file
@@ -3054,10 +3060,18 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(emitModuleJob.outputs[0].file, try toPath("Test.swiftmodule"))
     XCTAssertEqual(emitModuleJob.outputs[1].file, try toPath("Test.swiftdoc"))
     XCTAssertEqual(emitModuleJob.outputs[2].file, try toPath("Test.swiftsourceinfo"))
+#if os(Windows)
+    XCTAssertEqual(emitModuleJob.outputs[3].file, try toPath("Test.swiftinterface"))
+#else
     XCTAssertEqual(emitModuleJob.outputs[3].file, try VirtualPath(path: "./Test.swiftinterface"))
+#endif
     XCTAssertEqual(emitModuleJob.outputs[4].file, try toPath("Test.private.swiftinterface"))
     XCTAssertEqual(emitModuleJob.outputs[5].file, try toPath("Test-Swift.h"))
+#if os(Windows)
+    XCTAssertEqual(emitModuleJob.outputs[6].file, try toPath("Test.tbd"))
+#else
     XCTAssertEqual(emitModuleJob.outputs[6].file, try VirtualPath(path: "./Test.tbd"))
+#endif
     if driver1.targetTriple.isDarwin {
         XCTAssertEqual(emitModuleJob.outputs[7].file, try toPath("Test.abi.json"))
     }
@@ -3068,10 +3082,12 @@ final class SwiftDriverTests: XCTestCase {
 
 
   func testIndexFileEntryInSupplementaryFileOutputMap() throws {
+    let workingDirectory = AbsolutePath("/tmp")
     var driver1 = try Driver(args: [
       "swiftc", "foo1.swift", "foo2.swift", "foo3.swift", "foo4.swift", "foo5.swift",
       "-index-file", "-index-file-path", "foo5.swift", "-o", "/tmp/t.o",
-      "-index-store-path", "/tmp/idx", "-working-directory", "/tmp"
+      "-index-store-path", "/tmp/idx",
+      "-working-directory", workingDirectory.nativePathString(escaped: false)
     ])
     let plannedJobs = try driver1.planBuild().removingAutolinkExtractJobs()
     XCTAssertEqual(plannedJobs.count, 1)
@@ -3079,8 +3095,8 @@ final class SwiftDriverTests: XCTestCase {
     // This is to match the legacy driver behavior
     // Make sure the supplementary output map has an entry for the Swift file
     // under indexing and its indexData entry is the primary output file
-    let entry = try XCTUnwrap(map.entries[VirtualPath.absolute(try AbsolutePath(validating: "/tmp/foo5.swift")).intern()])
-    XCTAssertEqual(VirtualPath.lookup(entry[.indexData]!), .absolute(try .init(validating: "/tmp/t.o")))
+    let entry = try XCTUnwrap(map.entries[VirtualPath.absolute(workingDirectory.appending(component: "foo5.swift")).intern()])
+    XCTAssertEqual(VirtualPath.lookup(entry[.indexData]!), .absolute(workingDirectory.appending(component: "t.o")))
   }
 
   func testMultiThreadedWholeModuleOptimizationCompiles() throws {
@@ -3196,6 +3212,9 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testLinkFilelistWithDebugInfo() throws {
+#if os(Windows)
+    try XCTSkipIf(true, "platform linker does not support filelists")
+#endif
     func getFileListElements(for filelistOpt: String, job: Job) -> [VirtualPath] {
         guard let optIdx = job.commandLine.firstIndex(of: .flag(filelistOpt)) else {
             XCTFail("Argument '\(filelistOpt)' not in job command line")
@@ -5550,6 +5569,7 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
+#if !os(Windows) // Windows uses Foundation instead of TSC for subprocesses
     do {
       XCTAssertThrowsError(try Driver(args: ["swift", "-print-target-info"],
                                       env: ["SWIFT_DRIVER_SWIFT_FRONTEND_EXEC": "/bad/path/to/swift-frontend"])) {
@@ -5560,6 +5580,7 @@ final class SwiftDriverTests: XCTestCase {
         }
       }
     }
+#endif
 
     do {
       var driver = try Driver(args: ["swift", "-print-target-info", "-target", "x86_64-apple-ios13.1-macabi", "-target-variant", "x86_64-apple-macosx10.14", "-sdk", "bar", "-resource-dir", "baz"])
@@ -7000,11 +7021,19 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(diags.diagnostics.first!.message.text, Diagnostic.Message.error_need_wmo_embedded.text)
     } catch _ { }
     do {
+      var environment = ProcessEnv.vars
+      environment["SDKROOT"] = nil
+
       // Indexing embedded Swift code should not require WMO
       let diags = DiagnosticsEngine()
-      var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-index-file", "-index-file-path", "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-o", "a.out", "-module-name", "main"], diagnosticsEngine: diags)
+      var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-index-file", "-index-file-path", "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-o", "a.out", "-module-name", "main"], env: env, diagnosticsEngine: diags)
       _ = try driver.planBuild()
+#if os(Windows)
+      // warning: Could not read SDKSettings.json for SDK at: ${SDKROOT}
+      XCTAssertEqual(diags.diagnostics.count, 1)
+#else
       XCTAssertEqual(diags.diagnostics.count, 0)
+#endif
     }
     do {
       let diags = DiagnosticsEngine()
@@ -7020,7 +7049,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(plannedJobs.count, 1)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
-      XCTAssert(plannedJobs[0].commandLine.contains(subsequence: [.flag("-vfsoverlay"), try toPathOption("overlay.yaml")]))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-vfsoverlay"), toPathOption("overlay.yaml"))
     }
 
     // Verify that the overlays are passed to the frontend in the same order.
@@ -7029,7 +7058,7 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
       XCTAssertEqual(plannedJobs.count, 1)
       XCTAssertEqual(plannedJobs[0].kind, .compile)
-      XCTAssert(plannedJobs[0].commandLine.contains(subsequence: [.flag("-vfsoverlay"), try toPathOption("overlay1.yaml"), .flag("-vfsoverlay"), try toPathOption("overlay2.yaml"), .flag("-vfsoverlay"), try toPathOption("overlay3.yaml")]))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-vfsoverlay"), toPathOption("overlay1.yaml"), .flag("-vfsoverlay"), toPathOption("overlay2.yaml"), .flag("-vfsoverlay"), toPathOption("overlay3.yaml"))
     }
   }
 
@@ -7269,19 +7298,21 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
+      let workingDirectory = AbsolutePath("/foo/bar")
+
       // Inputs with relative paths with -working-directory flag should prefix all inputs
       var driver = try Driver(args: ["swiftc",
                                      "-target", "arm64-apple-ios13.1",
                                      "-resource-dir", "relresourcepath",
                                      "-sdk", "relsdkpath",
                                      "foo.swift",
-                                     "-working-directory", "/foo/bar"])
+                                     "-working-directory", workingDirectory.nativePathString(escaped: false)])
       let plannedJobs = try driver.planBuild()
       let compileJob = plannedJobs[0]
       XCTAssertEqual(compileJob.kind, .compile)
-      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-primary-file", try toPathOption("/foo/bar/foo.swift", isRelative: false)]))
-      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-resource-dir", try toPathOption("/foo/bar/relresourcepath", isRelative: false)]))
-      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-sdk", try toPathOption("/foo/bar/relsdkpath", isRelative: false)]))
+      try XCTAssertJobInvocationMatches(compileJob, .flag("-primary-file"), .path(.absolute(workingDirectory.appending(component: "foo.swift"))))
+      try XCTAssertJobInvocationMatches(compileJob, .flag("-resource-dir"), .path(.absolute(workingDirectory.appending(component: "relresourcepath"))))
+      try XCTAssertJobInvocationMatches(compileJob, .flag("-sdk"), .path(.absolute(workingDirectory.appending(component: "relsdkpath"))))
     }
 
     try withTemporaryFile { fileMapFile in
@@ -7306,33 +7337,33 @@ final class SwiftDriverTests: XCTestCase {
       let plannedJobs = try driver.planBuild()
       let compileJob = plannedJobs[0]
       XCTAssertEqual(compileJob.kind, .compile)
-      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-o", try toPathOption("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o", isRelative: false)]))
+      try XCTAssertJobInvocationMatches(compileJob, .flag("-o"), .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o"))))
     }
 
     try withTemporaryFile { fileMapFile in
-      let outputMapContents: ByteString = """
+      let outputMapContents: ByteString = .init(encodingAsUTF8: """
       {
         "": {
           "diagnostics": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.dia",
           "emit-module-diagnostics": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/master.emit-module.dia"
         },
-        "/some/workingdir/foo.swift": {
+        "\(AbsolutePath("/some/workingdir/foo.swift").nativePathString(escaped: true))": {
           "object": "/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o"
         }
       }
-      """
+      """)
       try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
 
       // Inputs with relative paths and working-dir should use absolute paths in output file maps
       var driver = try Driver(args: ["swiftc",
                                      "-target", "arm64-apple-ios13.1",
                                      "foo.swift",
-                                     "-working-directory", "/some/workingdir",
+                                     "-working-directory", AbsolutePath("/some/workingdir").nativePathString(escaped: false),
                                      "-output-file-map", fileMapFile.path.description])
       let plannedJobs = try driver.planBuild()
       let compileJob = plannedJobs[0]
       XCTAssertEqual(compileJob.kind, .compile)
-      XCTAssertTrue(compileJob.commandLine.contains(subsequence: ["-o", try toPathOption("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o", isRelative: false)]))
+      try XCTAssertJobInvocationMatches(compileJob, .flag("-o"), .path(.absolute(.init("/tmp/foo/.build/x86_64-apple-macosx/debug/foo.build/foo.o"))))
     }
   }
 
@@ -7489,21 +7520,21 @@ final class SwiftDriverTests: XCTestCase {
 
       let jobA = plannedJobs[0]
       let mapA = try XCTUnwrap(jobA.commandLine.supplementaryOutputFilemap)
-      let filesA = try XCTUnwrap(mapA.entries[try toPath("a.swift").intern()])
+      let filesA = try XCTUnwrap(mapA.entries[try toPath("./a.swift").intern()])
       XCTAssertTrue(filesA.keys.contains(.swiftModule))
       XCTAssertTrue(filesA.keys.contains(.swiftDocumentation))
       XCTAssertTrue(filesA.keys.contains(.swiftSourceInfoFile))
 
       let jobB = plannedJobs[1]
       let mapB = try XCTUnwrap(jobB.commandLine.supplementaryOutputFilemap)
-      let filesB = try XCTUnwrap(mapB.entries[try toPath("b.swift").intern()])
+      let filesB = try XCTUnwrap(mapB.entries[try toPath("./b.swift").intern()])
       XCTAssertTrue(filesB.keys.contains(.swiftModule))
       XCTAssertTrue(filesB.keys.contains(.swiftDocumentation))
       XCTAssertTrue(filesB.keys.contains(.swiftSourceInfoFile))
 
       let jobC = plannedJobs[2]
       let mapC = try XCTUnwrap(jobC.commandLine.supplementaryOutputFilemap)
-      let filesC = try XCTUnwrap(mapC.entries[try toPath("c.swift").intern()])
+      let filesC = try XCTUnwrap(mapC.entries[try toPath("./c.swift").intern()])
       XCTAssertTrue(filesC.keys.contains(.swiftModule))
       XCTAssertTrue(filesC.keys.contains(.swiftDocumentation))
       XCTAssertTrue(filesC.keys.contains(.swiftSourceInfoFile))
@@ -7522,7 +7553,7 @@ final class SwiftDriverTests: XCTestCase {
       guard case let .list(inputs) = inputFileList else {
         return XCTFail("FileList wasn't List")
       }
-      XCTAssertEqual(inputs, [try toPath("a.swift"), try toPath("b.swift"), try toPath("c.swift")])
+      XCTAssertEqual(inputs, [try toPath("./a.swift"), try toPath("./b.swift"), try toPath("./c.swift")])
 
       let outputsFlag = job.commandLine.firstIndex(of: .flag("-output-filelist"))!
       let outputFileListArgument = job.commandLine[job.commandLine.index(after: outputsFlag)]
@@ -7739,10 +7770,14 @@ final class SwiftDriverTests: XCTestCase {
   func pluginPathTest(platform: String, sdk: String, searchPlatform: String) throws {
     let sdkRoot = try testInputsPath.appending(
       components: ["Platform Checks", "\(platform).platform", "Developer", "SDKs", "\(sdk).sdk"])
+
     var env = ProcessEnv.vars
     env["PLATFORM_DIR"] = "/tmp/PlatformDir/\(platform).platform"
+
+    let workingDirectory = AbsolutePath("/tmp")
+
     var driver = try Driver(
-      args: ["swiftc", "-typecheck", "foo.swift", "-sdk", VirtualPath.absolute(sdkRoot).name, "-plugin-path", "PluginA", "-external-plugin-path", "Plugin~B#Bexe", "-load-plugin-library", "PluginB2", "-plugin-path", "PluginC", "-working-directory", "/tmp"],
+      args: ["swiftc", "-typecheck", "foo.swift", "-sdk", VirtualPath.absolute(sdkRoot).name, "-plugin-path", "PluginA", "-external-plugin-path", "Plugin~B#Bexe", "-load-plugin-library", "PluginB2", "-plugin-path", "PluginC", "-working-directory", workingDirectory.nativePathString(escaped: false)],
       env: env
     )
     guard driver.isFrontendArgSupported(.pluginPath) && driver.isFrontendArgSupported(.externalPluginPath) else {
@@ -7754,15 +7789,15 @@ final class SwiftDriverTests: XCTestCase {
     let job = jobs.first!
 
     // Check that the we have the plugin paths we expect, in the order we expect.
-    let pluginAIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(try .init(validating: "/tmp/PluginA")))))
+    let pluginAIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(workingDirectory.appending(component: "PluginA")))))
 
-    let pluginBIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(try .init(validating: "/tmp/Plugin~B#Bexe")))))
+    let pluginBIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(workingDirectory.appending(component: "Plugin~B#Bexe")))))
     XCTAssertLessThan(pluginAIndex, pluginBIndex)
 
-    let pluginB2Index = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(try .init(validating: "/tmp/PluginB2")))))
+    let pluginB2Index = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(workingDirectory.appending(component: "PluginB2")))))
     XCTAssertLessThan(pluginBIndex, pluginB2Index)
 
-    let pluginCIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(try .init(validating: "/tmp/PluginC")))))
+    let pluginCIndex = try XCTUnwrap(job.commandLine.firstIndex(of: .path(VirtualPath.absolute(workingDirectory.appending(component: "PluginC")))))
     XCTAssertLessThan(pluginB2Index, pluginCIndex)
 
     #if os(macOS)
@@ -7863,7 +7898,7 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertEqual(jobs.count, 1)
       let job = jobs.first!
       XCTAssertEqual(job.kind, .link)
-      XCTAssertJobInvocationMatches(job, .path(.absolute(resourceDir.appending(component: "swiftrt.obj"))))
+      XCTAssertJobInvocationMatches(job, .path(.absolute(resourceDir.appending(components: platform, arch, "swiftrt.obj"))))
     }
 
     do {
@@ -7992,8 +8027,13 @@ final class SwiftDriverTests: XCTestCase {
 
         // test if current working directory is searched before PATH
         do {
+#if os(Windows)
+          let separator = ";"
+#else
+          let separator = ":"
+#endif
           var driver = try Driver(args: ["swiftc", "-print-target-info"],
-                                  env: [PATH: toolsDirectory.pathString, SWIFT_SCANNER_LIB: customSwiftScan.pathString])
+                                  env: [PATH: [toolsDirectory.pathString, ProcessEnv.path!].joined(separator: separator), SWIFT_SCANNER_LIB: customSwiftScan.pathString])
           let jobs = try driver.planBuild()
           XCTAssertEqual(jobs.count, 1)
           XCTAssertEqual(jobs.first!.tool.name, anotherSwiftFrontend.pathString)

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -142,8 +142,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
               { argc, argvPtr in false },
               { diagKind, diagMessage in
                 guard let nonOptionalDiagMessage = diagMessage else {
-                  XCTFail("Invalid tooling diagnostic handler message")
-                  return
+                  return XCTFail("Invalid tooling diagnostic handler message")
                 }
                 XCTAssertEqual(diagKind, SWIFTDRIVER_TOOLING_DIAGNOSTIC_ERROR)
                 XCTAssertEqual(String(cString: nonOptionalDiagMessage),

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -116,7 +116,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
                 // Bridge argc back to [String]
                 let argvBufferPtr = UnsafeBufferPointer<UnsafePointer<CChar>?>(start: argvPtr, count: Int(argc))
                 let resultingFrontendArgs = argvBufferPtr.map { String(cString: $0!) }
-                print(resultingFrontendArgs)
+
                 XCTAssertTrue(resultingFrontendArgs.contains("-frontend"))
                 XCTAssertTrue(resultingFrontendArgs.contains("-c"))
                 XCTAssertTrue(resultingFrontendArgs.contains("-emit-module-path"))


### PR DESCRIPTION
With this set of changes, we now can run the test suite on Windows to completion, restoring the state to where it was originally.