### PR TITLE
Remove error for invalid swift caching configuration

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -264,11 +264,6 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     for dependencyModule in swiftDependencyArtifacts {
       inputs.append(TypedVirtualPath(file: dependencyModule.modulePath.path,
                                      type: .swiftModule))
-
-      let prebuiltHeaderDependencyPaths = dependencyModule.prebuiltHeaderDependencyPaths ?? []
-      if cas != nil && !prebuiltHeaderDependencyPaths.isEmpty {
-        throw DependencyScanningError.unsupportedConfigurationForCaching("module \(dependencyModule.moduleName) has bridging header dependency")
-      }
     }
     for moduleArtifactInfo in clangDependencyArtifacts {
       let clangModulePath =

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -39,7 +39,6 @@ public enum DependencyScanningError: LocalizedError, DiagnosticData, Equatable {
   case scanningLibraryInvocationMismatch(String, String)
   case scanningLibraryNotFound(AbsolutePath)
   case argumentQueryFailed
-  case unsupportedConfigurationForCaching(String)
 
   public var description: String {
     switch self {
@@ -65,8 +64,6 @@ public enum DependencyScanningError: LocalizedError, DiagnosticData, Equatable {
         return "Dependency Scanning library not found at path: \(path)"
       case .argumentQueryFailed:
         return "Supported compiler argument query failed"
-      case .unsupportedConfigurationForCaching(let reason):
-        return "Unsupported configuration for -cache-compile-job, consider turn off swift caching: \(reason)"
     }
   }
 

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -718,9 +718,9 @@ final class CachingBuildTests: XCTestCase {
                                      "-working-directory", path.nativePathString(escaped: true),
                                      main.nativePathString(escaped: true)] + sdkArgumentsForTesting,
                               interModuleDependencyOracle: dependencyOracle)
-      // This is currently not supported.
-      XCTAssertThrowsError(try driver.planBuild()) {
-        XCTAssertEqual($0 as? DependencyScanningError, .unsupportedConfigurationForCaching("module Foo has bridging header dependency"))
+      let jobs = try driver.planBuild()
+      for job in jobs {
+          XCTAssertFalse(job.outputCacheKeys.isEmpty)
       }
     }
   }


### PR DESCRIPTION
Currently, swift-driver emits an error when trying to importing a swift binary module that has a bridging header when swift caching is enabled. This turns out to be a very common configuration that we need to support.

It turns out most of the time, allowing the compilation to continue will result in a successful compilation. Even though in rare occasions where multiple bridging headers from the dependencies are involved with overlapping content, the compilation is going to fail with confusing error message, we will address that in swift compiler instead.

Thus the current error message is removed to allow more supported projects.