### PR TITLE
Consistently use JSON when encoding output file maps

### DIFF
--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -140,16 +140,15 @@ public struct OutputFileMap: Hashable, Codable {
   /// Store the output file map at the given path.
   public func store(
     fileSystem: FileSystem,
-    file: AbsolutePath,
-    diagnosticEngine: DiagnosticsEngine
+    file: AbsolutePath
   ) throws {
     let encoder = JSONEncoder()
 
   #if os(Linux) || os(Android)
-    encoder.outputFormatting = [.prettyPrinted]
+      encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
   #else
     if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-        encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
     }
   #endif
 

--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -17,8 +17,6 @@ import protocol TSCBasic.FileSystem
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.SHA256
 
-@_implementationOnly import Yams
-
 /// How the resolver is to handle usage of response files
 public enum ResponseFileHandling {
   case forced
@@ -166,33 +164,8 @@ public final class ArgsResolver {
   throws {
     // FIXME: Need a way to support this for distributed build systems...
     if let absPath = path.absolutePath {
-      // This uses Yams to escape and quote strings, but not to output the whole yaml file because
-      // it sometimes outputs mappings in explicit block format (https://yaml.org/spec/1.2/spec.html#id2798057)
-      // and the frontend (llvm) only seems to support implicit block format.
-      try fileSystem.writeFileContents(absPath) { out in
-        for (input, map) in outputFileMap.entries {
-          out.send("\(quoteAndEscape(path: VirtualPath.lookup(input))):")
-          if map.isEmpty {
-            out.send(" {}\n")
-          } else {
-            out.send("\n")
-            for (type, output) in map {
-              out.send("  \(type.name): \(quoteAndEscape(path: VirtualPath.lookup(output)))\n")
-            }
-          }
-        }
-      }
+        try outputFileMap.store(fileSystem: fileSystem, file: absPath)
     }
-  }
-
-  private func quoteAndEscape(path: VirtualPath) -> String {
-    let inputNode = Node.scalar(Node.Scalar(try! unsafeResolve(path: path),
-                                            Tag(.str), .doubleQuoted))
-    // Width parameter of -1 sets preferred line-width to unlimited so that no extraneous
-    // line-breaks will be inserted during serialization.
-    let string = try! Yams.serialize(node: inputNode, width: -1)
-    // Remove the newline from the end
-    return string.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   private func createResponseFileIfNeeded(for job: Job, resolvedArguments: inout [String], useResponseFiles: ResponseFileHandling) throws -> Bool {

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -1473,7 +1473,7 @@ final class SwiftDriverTests: XCTestCase {
     let sampleOutputFileMap = OutputFileMap(entries: pathyEntries)
 
     try withTemporaryFile { file in
-      try sampleOutputFileMap.store(fileSystem: localFileSystem, file: file.path, diagnosticEngine: DiagnosticsEngine())
+      try sampleOutputFileMap.store(fileSystem: localFileSystem, file: file.path)
       let contentsForDebugging = try localFileSystem.readFileContents(file.path).cString
       _ = contentsForDebugging
       let recoveredOutputFileMap = try OutputFileMap.load(fileSystem: localFileSystem, file: .absolute(file.path), diagnosticEngine: DiagnosticsEngine())
@@ -8289,6 +8289,55 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertTrue(plannedJobs[0].tool.name.hasSuffix("swift-frontend"))
     XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-load-pass-plugin=/path/to/plugin")))
 #endif
+  }
+    
+  func testSupplementaryOutputFileMapUsage() throws {
+    // Ensure filenames are escaped properly when using a supplementary output file map
+    try withTemporaryDirectory { path in
+      try localFileSystem.changeCurrentWorkingDirectory(to: path)
+      let moduleCachePath = path.appending(component: "ModuleCache")
+      try localFileSystem.createDirectory(moduleCachePath)
+      let one = path.appending(component: "one.swift")
+      let two = path.appending(component: "needs to escape spaces.swift")
+      let three = path.appending(component: #"another"one.swift"#)
+      let four = path.appending(component: "4.swift")
+      try localFileSystem.writeFileContents(one, bytes:
+        """
+        public struct A {}
+        """
+      )
+      try localFileSystem.writeFileContents(two, bytes:
+        """
+        struct B {}
+        """
+      )
+      try localFileSystem.writeFileContents(three, bytes:
+        """
+        struct C {}
+        """
+      )
+      try localFileSystem.writeFileContents(four, bytes:
+        """
+        struct D {}
+        """
+      )
+      
+      let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
+      let invocationArguments = ["swiftc",
+                                 "-parse-as-library",
+                                 "-emit-library",
+                                 "-driver-filelist-threshold", "0",
+                                 "-module-cache-path", moduleCachePath.nativePathString(escaped: true),
+                                 "-working-directory", path.nativePathString(escaped: true),
+                                 one.nativePathString(escaped: true),
+                                 two.nativePathString(escaped: true),
+                                 three.nativePathString(escaped: true),
+                                 four.nativePathString(escaped: true)] + sdkArgumentsForTesting
+      var driver = try Driver(args: invocationArguments)
+      let jobs = try driver.planBuild()
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
+    }
   }
 }
 


### PR DESCRIPTION
Simplify the encoding of output file maps and remove a yams dependency we don't need in this part of the driver