### PR TITLE
Remove now-unused yaml parser dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,15 +87,6 @@ if(NOT TSC_FOUND)
   FetchContent_MakeAvailable(ToolsSupportCore)
 endif()
 
-find_package(Yams CONFIG)
-if(NOT Yams_FOUND)
-  message("-- Vending yams")
-  FetchContent_Declare(Yams
-    GIT_REPOSITORY https://github.com/jpsim/yams
-    GIT_TAG 5.0.6)
-  FetchContent_MakeAvailable(Yams)
-endif()
-
 set(BUILD_TESTING ${_SD_SAVED_BUILD_TESTING})
 set(BUILD_EXAMPLES ${_SD_SAVED_BUILD_EXAMPLES})
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -35,15 +35,6 @@
         "branch" : "main",
         "revision" : "4074f4db0971328c441fc1621c673937b9ca3b08"
       }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
-        "version" : "5.1.3"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,6 @@ let package = Package(
         "SwiftOptions",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         "CSwiftScan",
-        .product(name: "Yams", package: "yams"),
       ],
       exclude: ["CMakeLists.txt"]),
 
@@ -166,7 +165,6 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: "main"),
-    .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "5.1.0")),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
     // dependency version changes here with those projects.
@@ -175,7 +173,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
 } else {
     package.dependencies += [
         .package(path: "../swift-tools-support-core"),
-        .package(path: "../yams"),
         .package(path: "../swift-argument-parser"),
     ]
 }

--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ all with CMake:
   cmake -B <llbuild-build-dir> -G Ninja <llbuild-source-dir> -DLLBUILD_SUPPORT_BINDINGS="Swift" -DCMAKE_OSX_ARCHITECTURES=x86_64
   ```
 * [swift-argument-parser](https://github.com/apple/swift-argument-parser)
-* [Yams](https://github.com/jpsim/Yams)
 
 Once those dependencies have built, build `swift-driver` itself:
 ```
-cmake -B <swift-driver-build-dir> -G Ninja <swift-driver-source-dir> -DTSC_DIR=<swift-tools-support-core-build-dir>/cmake/modules -DLLBuild_DIR=<llbuild-build-dir>/cmake/modules -DYams_DIR=<yamls-build-dir>/cmake/modules -DArgumentParser_DIR=<swift-argument-parser-build-dir>
+cmake -B <swift-driver-build-dir> -G Ninja <swift-driver-source-dir> -DTSC_DIR=<swift-tools-support-core-build-dir>/cmake/modules -DLLBuild_DIR=<llbuild-build-dir>/cmake/modules -DArgumentParser_DIR=<swift-argument-parser-build-dir>
 cmake --build <swift-driver-build-dir>
 ```
 

--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -131,8 +131,6 @@ target_link_libraries(SwiftDriver PUBLIC
   TSCUtility
   SwiftOptions)
 target_link_libraries(SwiftDriver PRIVATE
-  CYaml
-  Yams
   CSwiftScan)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS SwiftDriver)

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -445,9 +445,6 @@ def build_using_cmake(args, toolchain_bin, build_dir, targets):
     # Argument Parser
     build_argument_parser_using_cmake(args, target, swiftc_exec, dependencies_dir,
                                       base_cmake_flags, swift_flags)
-    # Yams
-    build_yams_using_cmake(args, target, swiftc_exec, dependencies_dir,
-                           base_cmake_flags, swift_flags)
     # SwiftDriver
     build_swift_driver_using_cmake(args, target, swiftc_exec, driver_dir,
                                    base_cmake_flags, swift_flags)
@@ -489,25 +486,6 @@ def build_tsc_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_flags
   cmake_build(args, swiftc_exec, tsc_cmake_flags, tsc_swift_flags,
               tsc_source_dir, tsc_build_dir)
 
-def build_yams_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_flags, swift_flags):
-  print('Building Swift Driver dependency: Yams')
-  yams_source_dir = os.path.join(os.path.dirname(args.package_path), 'yams')
-  yams_build_dir = os.path.join(build_dir, 'yams')
-  yams_cmake_flags = base_cmake_flags + [
-      '-DCMAKE_C_COMPILER:=clang',
-      '-DBUILD_SHARED_LIBS=OFF']
-
-  if '-apple-macosx' in args.build_target:
-    yams_cmake_flags.append('-DCMAKE_OSX_DEPLOYMENT_TARGET=%s' % macos_deployment_target)
-    yams_cmake_flags.append('-DCMAKE_C_FLAGS=-target %s' % target)
-  else:
-    yams_cmake_flags.append('-DCMAKE_C_FLAGS=-fPIC -target %s' % target)
-    if args.foundation_build_dir:
-      yams_cmake_flags.append(get_foundation_cmake_arg(args))
-  yams_swift_flags = swift_flags[:]
-  cmake_build(args, swiftc_exec, yams_cmake_flags, yams_swift_flags,
-              yams_source_dir, yams_build_dir)
-
 def build_argument_parser_using_cmake(args, target, swiftc_exec, build_dir, base_cmake_flags, swift_flags):
   print('Building Swift Driver dependency: Argument Parser')
   parser_source_dir = os.path.join(os.path.dirname(args.package_path), 'swift-argument-parser')
@@ -529,7 +507,6 @@ def build_swift_driver_using_cmake(args, target, swiftc_exec, build_dir, base_cm
   flags = [
         '-DLLBuild_DIR=' + os.path.join(os.path.join(dependencies_dir, 'llbuild'), 'cmake/modules'),
         '-DTSC_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-tools-support-core'), 'cmake/modules'),
-        '-DYams_DIR=' + os.path.join(os.path.join(dependencies_dir, 'yams'), 'cmake/modules'),
         '-DArgumentParser_DIR=' + os.path.join(os.path.join(dependencies_dir, 'swift-argument-parser'), 'cmake/modules')]
   driver_cmake_flags = base_cmake_flags + flags
   cmake_build(args, swiftc_exec, driver_cmake_flags, driver_swift_flags,


### PR DESCRIPTION
Now that old-style incremental build records are obsolete, this dependency is unused and we no longer need to build it as part of the driver