### PR TITLE
build: add additional target exports

### DIFF
--- a/Sources/CSwiftScan/CMakeLists.txt
+++ b/Sources/CSwiftScan/CMakeLists.txt
@@ -8,3 +8,4 @@
 
 add_library(CSwiftScan STATIC
   CSwiftScanImpl.c)
+set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS CSwiftScan)


### PR DESCRIPTION
When building swift-driver with static libraries, we need to add this additional export. This is meant to support building swift-driver with static libraries for use as the early swift-driver on Windows.