### PR TITLE
SwiftDriverTests: repair the tests on Windows

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -8339,7 +8339,7 @@ final class SwiftDriverTests: XCTestCase {
       try localFileSystem.createDirectory(moduleCachePath)
       let one = path.appending(component: "one.swift")
       let two = path.appending(component: "needs to escape spaces.swift")
-      let three = path.appending(component: #"another"one.swift"#)
+      let three = path.appending(component: "another'one.swift")
       let four = path.appending(component: "4.swift")
       try localFileSystem.writeFileContents(one, bytes:
         """


### PR DESCRIPTION
`"` is an invalid filesystem character, you may not use this in a file name. Replace the character with `'`. This repairs the test suite on Windows.