### PR TITLE
[Incremental Builds][Explicit Module Builds] Switch to using incremental dependency scanning

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -315,10 +315,6 @@ public struct Driver {
   /// Set during planning because needs the jobs to look at outputs.
   @_spi(Testing) public private(set) var incrementalCompilationState: IncrementalCompilationState? = nil
 
-  /// Nil if not running in explicit module build mode.
-  /// Set during planning.
-  var interModuleDependencyGraph: InterModuleDependencyGraph? = nil
-
   /// The path of the SDK.
   public var absoluteSDKPath: AbsolutePath? {
     guard let path = frontendTargetInfo.sdkPath?.path else {
@@ -1908,7 +1904,6 @@ extension Driver {
     try executor.execute(
       workload: .init(allJobs,
                       incrementalCompilationState,
-                      interModuleDependencyGraph,
                       continueBuildingAfterErrors: continueBuildingAfterErrors),
       delegate: jobExecutionDelegate,
       numParallelJobs: numParallelJobs ?? 1,
@@ -1936,16 +1931,6 @@ extension Driver {
         .warning("next compile won't be incremental; could not write dependency graph: \(error.localizedDescription)"))
       /// Ensure that a bogus dependency graph is not used next time.
       buildRecordInfo.removeBuildRecord()
-      buildRecordInfo.removeInterModuleDependencyGraph()
-      return
-    }
-    do {
-      try incrementalCompilationState.writeInterModuleDependencyGraph(buildRecordInfo)
-    } catch {
-      diagnosticEngine.emit(
-        .warning("next compile must run a full dependency scan; could not write inter-module dependency graph: \(error.localizedDescription)"))
-      buildRecordInfo.removeBuildRecord()
-      buildRecordInfo.removeInterModuleDependencyGraph()
       return
     }
   }

--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -61,22 +61,27 @@ public struct DriverExecutorWorkload {
   }
 
   public let kind: Kind
-  public let interModuleDependencyGraph: InterModuleDependencyGraph?
+
+  @available(*, deprecated, message: "use of 'interModuleDependencyGraph' on 'DriverExecutorWorkload' is deprecated")
+  public let interModuleDependencyGraph: InterModuleDependencyGraph? = nil
 
   public init(_ allJobs: [Job],
               _ incrementalCompilationState: IncrementalCompilationState?,
-              _ interModuleDependencyGraph: InterModuleDependencyGraph?,
               continueBuildingAfterErrors: Bool) {
     self.continueBuildingAfterErrors = continueBuildingAfterErrors
     self.kind = incrementalCompilationState
       .map {.incremental($0)}
       ?? .all(allJobs)
-    self.interModuleDependencyGraph = interModuleDependencyGraph
   }
 
+  static public func all(_ jobs: [Job]) -> Self {
+    .init(jobs, nil, continueBuildingAfterErrors: false)
+  }
+
+  @available(*, deprecated, message: "use all(_ jobs: [Job]) instead")
   static public func all(_ jobs: [Job],
-                         _ interModuleDependencyGraph: InterModuleDependencyGraph? = nil) -> Self {
-    .init(jobs, nil, interModuleDependencyGraph, continueBuildingAfterErrors: false)
+                         _ interModuleDependencyGraph: InterModuleDependencyGraph?) -> Self {
+    .init(jobs, nil, continueBuildingAfterErrors: false)
   }
 }
 
@@ -119,7 +124,7 @@ extension DriverExecutor {
     recordedInputModificationDates: [TypedVirtualPath: TimePoint]
   ) throws {
     try execute(
-      workload: .all(jobs, nil),
+      workload: .all(jobs),
       delegate: delegate,
       numParallelJobs: numParallelJobs,
       forceResponseFiles: forceResponseFiles,

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -174,7 +174,7 @@ internal extension InterModuleDependencyGraph {
                               reporter: reporter)
     }
 
-    if forRebuild {
+    if forRebuild && !modulesRequiringRebuild.isEmpty {
       reporter?.reportExplicitDependencyReBuildSet(Array(modulesRequiringRebuild))
     }
     return modulesRequiringRebuild

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -141,6 +141,28 @@ public extension Driver {
       }
     }
 
+    if (parsedOptions.contains(.driverShowIncremental) ||
+        parsedOptions.contains(.dependencyScanCacheRemarks)) &&
+       isFrontendArgSupported(.dependencyScanCacheRemarks) {
+      commandLine.appendFlag(.dependencyScanCacheRemarks)
+    }
+
+    if shouldAttemptIncrementalCompilation &&
+       parsedOptions.contains(.incrementalDependencyScan) {
+      if let serializationPath = buildRecordInfo?.dependencyScanSerializedResultPath {
+        if isFrontendArgSupported(.validatePriorDependencyScanCache) {
+          // Any compiler which supports "-validate-prior-dependency-scan-cache"
+          // also supports "-load-dependency-scan-cache"
+          // and "-serialize-dependency-scan-cache" and "-dependency-scan-cache-path"
+          commandLine.appendFlag(.dependencyScanCachePath)
+          commandLine.appendPath(serializationPath)
+          commandLine.appendFlag(.reuseDependencyScanCache)
+          commandLine.appendFlag(.validatePriorDependencyScanCache)
+          commandLine.appendFlag(.serializeDependencyScanCache)
+        }
+      }
+    }
+
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.filter { $0.type == .swift }.map { .path($0.file) })
     return (inputs, commandLine)

--- a/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/BuildRecordInfo.swift
@@ -177,29 +177,6 @@ import class Dispatch.DispatchQueue
     try? fileSystem.removeFileTree(absPath)
   }
 
-  func removeInterModuleDependencyGraph() {
-    guard let absPath = interModuleDependencyGraphPath.absolutePath else {
-      return
-    }
-    try? fileSystem.removeFileTree(absPath)
-  }
-
-  func readPriorInterModuleDependencyGraph(
-    reporter: IncrementalCompilationState.Reporter?
-  ) -> InterModuleDependencyGraph? {
-    let decodedGraph: InterModuleDependencyGraph
-    do {
-      let contents = try fileSystem.readFileContents(interModuleDependencyGraphPath).cString
-      decodedGraph = try JSONDecoder().decode(InterModuleDependencyGraph.self,
-                                              from: Data(contents.utf8))
-    } catch {
-      return nil
-    }
-    reporter?.report("Read inter-module dependency graph", interModuleDependencyGraphPath)
-
-    return decodedGraph
-  }
-
   func jobFinished(job: Job, result: ProcessResult) {
     self.confinementQueue.sync {
       finishedJobResults.append(JobResult(job, result))
@@ -220,11 +197,11 @@ import class Dispatch.DispatchQueue
 
   /// A build-record-relative path to the location of a serialized copy of the
   /// driver's inter-module dependency graph.
-  var interModuleDependencyGraphPath: VirtualPath {
+  var dependencyScanSerializedResultPath: VirtualPath {
     let filename = buildRecordPath.basenameWithoutExt
     return buildRecordPath
       .parentDirectory
-      .appending(component: filename + ".moduledeps")
+      .appending(component: filename + ".swiftmoduledeps")
   }
 
   /// Directory to emit dot files into

--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -26,7 +26,6 @@ extension IncrementalCompilationState {
     let showJobLifecycle: Bool
     let alwaysRebuildDependents: Bool
     let interModuleDependencyGraph: InterModuleDependencyGraph?
-    let explicitModuleDependenciesGuaranteedUpToDate: Bool
     /// If non-null outputs information for `-driver-show-incremental` for input path
     private let reporter: Reporter?
 
@@ -47,8 +46,6 @@ extension IncrementalCompilationState {
       self.alwaysRebuildDependents = initialState.incrementalOptions.contains(
         .alwaysRebuildDependents)
       self.interModuleDependencyGraph = interModuleDependencyGraph
-      self.explicitModuleDependenciesGuaranteedUpToDate =
-        initialState.upToDatePriorInterModuleDependencyGraph != nil ? true : false
       self.reporter = reporter
     }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -53,7 +53,8 @@ public final class IncrementalCompilationState {
   internal init(
     driver: inout Driver,
     jobsInPhases: JobsInPhases,
-    initialState: InitialStateForPlanning
+    initialState: InitialStateForPlanning,
+    interModuleDepGraph: InterModuleDependencyGraph?
   ) throws {
     let reporter = initialState.incrementalOptions.contains(.showIncremental)
       ? Reporter(diagnosticEngine: driver.diagnosticEngine,
@@ -64,12 +65,12 @@ public final class IncrementalCompilationState {
       initialState: initialState,
       jobsInPhases: jobsInPhases,
       driver: driver,
-      interModuleDependencyGraph: driver.interModuleDependencyGraph,
+      interModuleDependencyGraph: interModuleDepGraph,
       reporter: reporter)
       .compute(batchJobFormer: &driver)
 
     self.info = initialState.graph.info
-    self.upToDateInterModuleDependencyGraph = driver.interModuleDependencyGraph
+    self.upToDateInterModuleDependencyGraph = interModuleDepGraph
     self.protectedState = ProtectedState(
       skippedCompileJobs: firstWave.initiallySkippedCompileJobs,
       initialState.graph,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -293,6 +293,7 @@ extension Option {
   public static let driverVerifyFineGrainedDependencyGraphAfterEveryImport: Option = Option("-driver-verify-fine-grained-dependency-graph-after-every-import", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Debug DriverGraph by verifying it after every import", group: .internalDebug)
   public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver")
   public static let dumpApiPath: Option = Option("-dump-api-path", .separate, attributes: [.frontend, .noDriver, .cacheInvariant], helpText: "The path to output swift interface files for the compiled source files")
+  public static let dumpAstFormat: Option = Option("-dump-ast-format", .separate, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], metaVar: "<format>", helpText: "Desired format for -dump-ast output ('default', 'json', or 'json-zlib'); no format is guaranteed stable across different compiler versions")
   public static let dumpAst: Option = Option("-dump-ast", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Parse and type-check input file(s) and dump AST(s)", group: .modes)
   public static let dumpAvailabilityScopes: Option = Option("-dump-availability-scopes", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Type-check input file(s) and dump availability scopes", group: .modes)
   public static let dumpClangDiagnostics: Option = Option("-dump-clang-diagnostics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Dump Clang diagnostics to stderr")
@@ -591,6 +592,7 @@ extension Option {
   public static let inProcessPluginServerPath: Option = Option("-in-process-plugin-server-path", .separate, attributes: [.frontend, .argumentIsPath], helpText: "Path to dynamic library plugin server")
   public static let includeSpiSymbols: Option = Option("-include-spi-symbols", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Add symbols with SPI information to the symbol graph")
   public static let includeSubmodules: Option = Option("-include-submodules", .flag, attributes: [.noDriver, .synthesizeInterface], helpText: "Also print the declarations synthesized for any Clang submodules")
+  public static let incrementalDependencyScan: Option = Option("-incremental-dependency-scan", .flag, attributes: [.helpHidden], helpText: "Re-use/validate prior build dependency scan artifacts")
   public static let incremental: Option = Option("-incremental", .flag, attributes: [.helpHidden, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Perform an incremental build if possible")
   public static let indentSwitchCase: Option = Option("-indent-switch-case", .flag, attributes: [.noInteractive, .noBatch], helpText: "Indent cases in switch statements.", group: .codeFormatting)
   public static let indentWidth: Option = Option("-indent-width", .separate, attributes: [.noInteractive, .noBatch], metaVar: "<n>", helpText: "Number of characters to indent.", group: .codeFormatting)
@@ -625,7 +627,7 @@ extension Option {
   public static let lineRange: Option = Option("-line-range", .separate, attributes: [.noInteractive, .noBatch], metaVar: "<n:n>", helpText: "<start line>:<end line>. Formats a range of lines (1-based). Can only be used with one input file.", group: .codeFormatting)
   public static let linkObjcRuntime: Option = Option("-link-objc-runtime", .flag, attributes: [.doesNotAffectIncrementalBuild], helpText: "Deprecated")
   public static let lldbRepl: Option = Option("-lldb-repl", .flag, attributes: [.helpHidden, .noBatch], helpText: "LLDB-enhanced REPL mode", group: .modes)
-  public static let reuseDependencyScanCache: Option = Option("-load-dependency-scan-cache", .flag, attributes: [.frontend, .noDriver], helpText: "After performing a dependency scan, serialize the scanner's internal state.")
+  public static let reuseDependencyScanCache: Option = Option("-load-dependency-scan-cache", .flag, attributes: [.frontend, .noDriver], helpText: "For performing a dependency scan, deserialize the scanner's internal state from a prior scan.")
   public static let loadPassPluginEQ: Option = Option("-load-pass-plugin=", .joined, attributes: [.frontend, .argumentIsPath], metaVar: "<path>", helpText: "Load LLVM pass plugin from a dynamic shared object file.")
   public static let loadPluginExecutable: Option = Option("-load-plugin-executable", .separate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath], metaVar: "<path>#<module-names>", helpText: "Path to a compiler plugin executable and a comma-separated list of module names where the macro types are declared", group: .pluginSearch)
   public static let loadPluginLibrary: Option = Option("-load-plugin-library", .separate, attributes: [.frontend, .doesNotAffectIncrementalBuild, .argumentIsPath], metaVar: "<path>", helpText: "Path to a dynamic library containing compiler plugins such as macros", group: .pluginSearch)
@@ -817,12 +819,12 @@ extension Option {
   public static let skipInheritedDocs: Option = Option("-skip-inherited-docs", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Skip emitting doc comments for members inherited through classes or default implementations")
   public static let skipProtocolImplementations: Option = Option("-skip-protocol-implementations", .flag, attributes: [.helpHidden, .frontend, .noInteractive, .supplementaryOutput], helpText: "Skip emitting symbols that are implementations of protocol requirements or inherited from protocol extensions")
   public static let skipSynthesizedMembers: Option = Option("-skip-synthesized-members", .flag, attributes: [.noDriver], helpText: "Skip members inherited through classes or default implementations")
-  public static let solverDisableShrink: Option = Option("-solver-disable-shrink", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable the shrink phase of expression type checking")
-  public static let solverExpressionTimeThresholdEQ: Option = Option("-solver-expression-time-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver])
+  public static let solverDisableSplitter: Option = Option("-solver-disable-splitter", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable the component splitter phase of expression type checking")
+  public static let solverExpressionTimeThresholdEQ: Option = Option("-solver-expression-time-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Expression type checking timeout, in seconds")
   public static let solverMemoryThreshold: Option = Option("-solver-memory-threshold", .separate, attributes: [.helpHidden, .frontend, .doesNotAffectIncrementalBuild], helpText: "Set the upper bound for memory consumption, in bytes, by the constraint solver")
-  public static let solverScopeThresholdEQ: Option = Option("-solver-scope-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver])
+  public static let solverScopeThresholdEQ: Option = Option("-solver-scope-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Expression type checking scope limit")
   public static let solverShrinkUnsolvedThreshold: Option = Option("-solver-shrink-unsolved-threshold", .separate, attributes: [.helpHidden, .frontend, .doesNotAffectIncrementalBuild], helpText: "Set The upper bound to number of sub-expressions unsolved before termination of the shrink phrase")
-  public static let solverTrailThresholdEQ: Option = Option("-solver-trail-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver])
+  public static let solverTrailThresholdEQ: Option = Option("-solver-trail-threshold=", .joined, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Expression type checking trail change limit")
   public static let stackPromotionLimit: Option = Option("-stack-promotion-limit", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Limit the size of stack promoted objects to the provided number of bytes.")
   public static let staticExecutable: Option = Option("-static-executable", .flag, helpText: "Statically link the executable")
   public static let staticStdlib: Option = Option("-static-stdlib", .flag, attributes: [.doesNotAffectIncrementalBuild], helpText: "Statically link the Swift standard library")
@@ -886,6 +888,7 @@ extension Option {
   public static let useTabs: Option = Option("-use-tabs", .flag, attributes: [.noInteractive, .noBatch], helpText: "Use tabs for indentation.", group: .codeFormatting)
   public static let userModuleVersion: Option = Option("-user-module-version", .separate, attributes: [.frontend, .moduleInterface], metaVar: "<vers>", helpText: "Module version specified from Swift module authors")
   public static let validateClangModulesOnce: Option = Option("-validate-clang-modules-once", .flag, attributes: [.frontend], helpText: "Don't verify input files for Clang modules if the module has been successfully validated or loaded during this build session")
+  public static let validatePriorDependencyScanCache: Option = Option("-validate-prior-dependency-scan-cache", .flag, attributes: [.frontend, .noDriver], helpText: "For performing a dependency scan with a prior scanner state, validate module dependencies.")
   public static let validateTbdAgainstIrEQ: Option = Option("-validate-tbd-against-ir=", .joined, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<level>", helpText: "Compare the symbols in the IR against the TBD file that would be generated.")
   public static let valueRecursionThreshold: Option = Option("-value-recursion-threshold", .separate, attributes: [.helpHidden, .frontend, .doesNotAffectIncrementalBuild], helpText: "Set the maximum depth for direct recursion in value types")
   public static let verifyAdditionalFile: Option = Option("-verify-additional-file", .separate, attributes: [.frontend, .noDriver], helpText: "Verify diagnostics in this file in addition to source files")
@@ -1214,6 +1217,7 @@ extension Option {
       Option.driverVerifyFineGrainedDependencyGraphAfterEveryImport,
       Option.driverWarnUnusedOptions,
       Option.dumpApiPath,
+      Option.dumpAstFormat,
       Option.dumpAst,
       Option.dumpAvailabilityScopes,
       Option.dumpClangDiagnostics,
@@ -1512,6 +1516,7 @@ extension Option {
       Option.inProcessPluginServerPath,
       Option.includeSpiSymbols,
       Option.includeSubmodules,
+      Option.incrementalDependencyScan,
       Option.incremental,
       Option.indentSwitchCase,
       Option.indentWidth,
@@ -1738,7 +1743,7 @@ extension Option {
       Option.skipInheritedDocs,
       Option.skipProtocolImplementations,
       Option.skipSynthesizedMembers,
-      Option.solverDisableShrink,
+      Option.solverDisableSplitter,
       Option.solverExpressionTimeThresholdEQ,
       Option.solverMemoryThreshold,
       Option.solverScopeThresholdEQ,
@@ -1807,6 +1812,7 @@ extension Option {
       Option.useTabs,
       Option.userModuleVersion,
       Option.validateClangModulesOnce,
+      Option.validatePriorDependencyScanCache,
       Option.validateTbdAgainstIrEQ,
       Option.valueRecursionThreshold,
       Option.verifyAdditionalFile,

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -210,7 +210,7 @@ do {
       }
     }
     do {
-      try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, nil, continueBuildingAfterErrors: true),
+      try executor.execute(workload: DriverExecutorWorkload.init(jobs, nil, continueBuildingAfterErrors: true),
                            delegate: delegate, numParallelJobs: 128)
     } catch {
       // Only fail when critical failures happened.
@@ -220,7 +220,7 @@ do {
     }
     do {
       if !danglingJobs.isEmpty && delegate.shouldRunDanglingJobs {
-        try executor.execute(workload: DriverExecutorWorkload.init(danglingJobs, nil, nil, continueBuildingAfterErrors: true), delegate: delegate, numParallelJobs: 128)
+        try executor.execute(workload: DriverExecutorWorkload.init(danglingJobs, nil, continueBuildingAfterErrors: true), delegate: delegate, numParallelJobs: 128)
       }
     } catch {
       // Failing of dangling jobs don't fail the process.


### PR DESCRIPTION
For Explicit Module Builds, have the driver configure the dependency scanner invocation to serialize its internal scanner cache state after a scan, and attempt to deserialize a prior build's scanner cache state, and validate its contents for an incremental re-scan.

Using functionality implemented in: https://github.com/swiftlang/swift/pull/78962