### PR TITLE
[Caching] Invalidate built module if missing from CAS

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -317,6 +317,10 @@ extension IncrementalCompilationState {
       report("Following explicit module dependencies will be re-built: [\(modules.map { $0.moduleNameForDiagnostic }.sorted().joined(separator: ", "))]")
     }
 
+    func reportExplicitDependencyMissingFromCAS(_ moduleName: String) {
+      report("Dependency module \(moduleName) is missing from CAS")
+    }
+
     // Emits a remark indicating incremental compilation has been disabled.
     func reportDisablingIncrementalBuild(_ why: String) {
       report("Disabling incremental build: \(why)")

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalDependencyAndInputSetup.swift
@@ -120,6 +120,7 @@ extension IncrementalCompilationState.IncrementalDependencyAndInputSetup {
 
     // Verify that each dependnecy is up-to-date with respect to its inputs
     guard try priorInterModuleDependencyGraph.computeInvalidatedModuleDependencies(fileSystem: buildRecordInfo.fileSystem,
+                                                                                   cas: driver.cas,
                                                                                    forRebuild: false,
                                                                                    reporter: reporter).isEmpty else {
       reporter?.reportExplicitBuildMustReScan("Not all dependencies are up-to-date.")

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -236,6 +236,7 @@ extension Driver {
       mandatoryModuleCompileJobs =
         try resolvedDependencyGraph.filterMandatoryModuleDependencyCompileJobs(modulePrebuildJobs,
                                                                                fileSystem: fileSystem,
+                                                                               cas: cas,
                                                                                reporter: reporter)
     }
     mandatoryModuleCompileJobs.forEach(addJob)

--- a/TestInputs/ExplicitModuleBuilds/Swift/O.swiftinterface
+++ b/TestInputs/ExplicitModuleBuilds/Swift/O.swiftinterface
@@ -1,0 +1,3 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name O -parse-stdlib
+public func none() { }


### PR DESCRIPTION
For swift caching build, swift-frontend only reads from CAS for inputs for full build reproducibility. In this case, if the CAS is removed, we need to treat the modules as missing from CAS and rebuild them, even if the version on disk appears to pass the up-to-date check.

rdar://135718227