### PR TITLE
Consistently use canImport(Darwin) throughout the codebase

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/Loader.swift
+++ b/Sources/SwiftDriver/SwiftScan/Loader.swift
@@ -15,7 +15,7 @@ import var Foundation.NSLocalizedDescriptionKey
 
 #if os(Windows)
 import WinSDK
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
@@ -121,7 +121,7 @@ extension Loader.Flags {
     }
 
     // Platform-specific flags
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
     public static var first: Loader.Flags {
       Loader.Flags(rawValue: RTLD_FIRST)
     }

--- a/Sources/SwiftDriver/Utilities/DateAdditions.swift
+++ b/Sources/SwiftDriver/Utilities/DateAdditions.swift
@@ -12,7 +12,7 @@
 
 #if os(Windows)
 import WinSDK
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/swift-build-sdk-interfaces/main.swift
+++ b/Sources/swift-build-sdk-interfaces/main.swift
@@ -13,7 +13,7 @@ import SwiftDriverExecution
 import SwiftDriver
 #if os(Windows)
 import CRT
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -14,7 +14,7 @@ import SwiftDriver
 import SwiftOptions
 #if os(Windows)
 import CRT
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2915,7 +2915,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testSanitizeStableAbi() throws {
-#if !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+#if !canImport(Darwin)
       throw XCTSkip("-sanitize-stable-abi is only implemented on Darwin")
 #else
     var driver = try Driver(args: ["swiftc", "-sanitize=address", "-sanitize-stable-abi", "Test.swift"])
@@ -7243,7 +7243,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testSwiftClangxxOverride() throws {
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
       throw XCTSkip("Darwin always uses `clang` to link")
 #else
     var env = ProcessEnv.vars
@@ -7876,7 +7876,7 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testCxxLinking() throws {
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
       throw XCTSkip("Darwin does not use clang as the linker driver")
 #else
       VirtualPath.resetTemporaryFileStore()


### PR DESCRIPTION
Easier than listing every Apple platform and keeping that list updated.