### PR TITLE
Enable PACBTI on OpenBSD/arm64.

### DIFF
--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -161,5 +161,15 @@ public final class GenericUnixToolchain: Toolchain {
         try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
       }
     }
+
+
+    if driver.targetTriple.os == .openbsd && driver.targetTriple.arch == .aarch64 {
+      commandLine.appendFlag(.Xcc)
+      commandLine.appendFlag("-Xclang=-msign-return-address=non-leaf")
+      commandLine.appendFlag(.Xcc)
+      commandLine.appendFlag("-Xclang=-msign-return-address-key=a_key")
+      commandLine.appendFlag(.Xcc)
+      commandLine.appendFlag("-Xclang=-mbranch-target-enforce")
+    }
   }
 }


### PR DESCRIPTION
BTI enforcement is mandatory, which means if PAC and BTI instructions are not emitted, then the compiled binary gets killed with SIGILL. The platform default compiler achieves enabling PAC and BTI by embedding the relevant enabled Clang compilation option flags into the local platform toolchain, which affects C/C++ code generation.

For bootstrapping purposes, we need to make this change in the legacy C++ driver in swiftlang/swift#78394; this is the equivalent change for the new driver.

It's not quite clear whether the flags need to be introduced in BackendJob.swift as well as FrontendJobHelpers.swift; just in case, add them in both locations.