### PR TITLE
[NFC] Remove a redundant return statement

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2791,7 +2791,6 @@ extension Driver {
         debugInfoLevel: debugInfoLevel,
         diagnosticsEngine: diagnosticsEngine,
         workingDirectory: workingDirectory)
-    return nil
   }
 
   /// Determine how the module will be emitted and the name of the module.


### PR DESCRIPTION
Silence `warning: code after 'return' will never be executed`