### PR TITLE
[GeneratePCH] Don't assert when libSwiftScan is not initialized

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -79,8 +79,8 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
   }
 
   /// Supports resolving bridging header pch command from swiftScan.
-  public func supportsBridgingHeaderPCHCommand() throws -> Bool {
-    return try swiftScanOracle.supportsBridgingHeaderPCHCommand()
+  public var supportsBridgingHeaderPCHCommand: Bool {
+    return swiftScanOracle.supportsBridgingHeaderPCHCommand
   }
 
   /// Generate build jobs for all dependencies of the main module.

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -118,9 +118,10 @@ public class InterModuleDependencyOracle {
     return swiftScan.supportsBinaryModuleHeaderDependencies || swiftScan.supportsBinaryModuleHeaderDependency
   }
 
-  @_spi(Testing) public func supportsBridgingHeaderPCHCommand() throws -> Bool {
+  @_spi(Testing) public var supportsBridgingHeaderPCHCommand: Bool {
     guard let swiftScan = swiftScanLibInstance else {
-      fatalError("Attempting to query supported scanner API with no scanner instance.")
+      // If no scanner, feature is not supported.
+      return false
     }
     return swiftScan.supportsBridgingHeaderPCHCommand
   }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -852,8 +852,8 @@ extension Driver {
 
 
   /// If explicit dependency planner supports creating bridging header pch command.
-  public func supportsBridgingHeaderPCHCommand() throws -> Bool {
-    return try explicitDependencyBuildPlanner?.supportsBridgingHeaderPCHCommand() ?? false
+  public var supportsBridgingHeaderPCHCommand: Bool {
+    return explicitDependencyBuildPlanner?.supportsBridgingHeaderPCHCommand ?? false
   }
 
   /// In Explicit Module Build mode, distinguish between main module jobs and intermediate dependency build jobs,

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -30,7 +30,7 @@ extension Driver {
 
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
 
-    if try supportsBridgingHeaderPCHCommand() {
+    if supportsBridgingHeaderPCHCommand {
       try addExplicitPCHBuildArguments(inputs: &inputs, commandLine: &commandLine)
       addCacheReplayMapping(to: &commandLine)
     } else {


### PR DESCRIPTION
Do not assert if libSwiftScan is not initialized when querying PCH generation feature. If libSwiftScan is not initialized, then the feature is not available so just return false for not available.

rdar://141554457