### PR TITLE
[6.1] Add support for `-disable-dynamic-actor-isolation`

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -367,6 +367,10 @@ extension Driver {
       try commandLine.appendLast(.disableSandbox, from: &parsedOptions)
     }
 
+    if isFrontendArgSupported(.disableDynamicActorIsolation) {
+      try commandLine.appendLast(.disableDynamicActorIsolation, from: &parsedOptions)
+    }
+
     if !directModuleCC1Mode, let workingDirectory = workingDirectory {
       // Add -Xcc -working-directory before any other -Xcc options to ensure it is
       // overridden by an explicit -Xcc -working-directory, although having a

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -3859,6 +3859,19 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-enable-bare-slash-regex")))
   }
 
+  func testDisableDynamicActorIsolation() throws {
+    var driver = try Driver(args: ["swiftc", "test.swift", "-disable-dynamic-actor-isolation"])
+    guard driver.isFrontendArgSupported(.disableDynamicActorIsolation) else {
+      throw XCTSkip("Skipping: compiler does not support '-disable-dynamic-actor-isolation'")
+    }
+    let plannedJobs = try driver.planBuild()
+    XCTAssertEqual(plannedJobs.count, 2)
+    XCTAssertEqual(plannedJobs[0].kind, .compile)
+    XCTAssertEqual(plannedJobs[1].kind, .link)
+    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-frontend")))
+    XCTAssertTrue(plannedJobs[0].commandLine.contains(.flag("-disable-dynamic-actor-isolation")))
+  }
+
   func testImmediateMode() throws {
     do {
       var driver = try Driver(args: ["swift", "foo.swift"])


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-driver/pull/1796

---

- Explanation:

  Allows to use `-disable-dynamic-actor-isolation` with new driver invocations, otherwise users won't be able to use it.

- Main Branch PR: https://github.com/swiftlang/swift-driver/pull/1796

- Risk: Very Low

- Reviewed By: @artemcm 

- Resolves: rdar://143965800

- Testing: Added new tests to the Sema test suite.

Resolves: https://github.com/swiftlang/swift/issues/77192

(cherry picked from commit fc965ea65b332bad5ca4f7e0d5d32906f4b545c5)