### PR TITLE
🍒 [6.1] Pass the `-dump-ast-format` flag down to the frontend.

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -276,6 +276,9 @@ extension Driver {
     try commandLine.appendLast(.lto, from: &parsedOptions)
     try commandLine.appendLast(.accessNotesPath, from: &parsedOptions)
     try commandLine.appendLast(.enableActorDataRaceChecks, .disableActorDataRaceChecks, from: &parsedOptions)
+    if isFrontendArgSupported(.dumpAstFormat) {
+      try commandLine.appendLast(.dumpAstFormat, from: &parsedOptions)
+    }
     try commandLine.appendAll(.D, from: &parsedOptions)
     try commandLine.appendAll(.debugPrefixMap, .coveragePrefixMap, .filePrefixMap, from: &parsedOptions)
     try commandLine.appendAllArguments(.Xfrontend, from: &parsedOptions)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -292,6 +292,7 @@ extension Option {
   public static let driverVerifyFineGrainedDependencyGraphAfterEveryImport: Option = Option("-driver-verify-fine-grained-dependency-graph-after-every-import", .flag, attributes: [.helpHidden, .doesNotAffectIncrementalBuild], helpText: "Debug DriverGraph by verifying it after every import", group: .internalDebug)
   public static let driverWarnUnusedOptions: Option = Option("-driver-warn-unused-options", .flag, attributes: [.helpHidden], helpText: "Emit warnings for any provided options which are unused by the driver")
   public static let dumpApiPath: Option = Option("-dump-api-path", .separate, attributes: [.frontend, .noDriver, .cacheInvariant], helpText: "The path to output swift interface files for the compiled source files")
+  public static let dumpAstFormat: Option = Option("-dump-ast-format", .separate, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], metaVar: "<format>", helpText: "Desired format for -dump-ast output ('default', 'json', or 'json-zlib'); no format is guaranteed stable across different compiler versions")
   public static let dumpAst: Option = Option("-dump-ast", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Parse and type-check input file(s) and dump AST(s)", group: .modes)
   public static let dumpAvailabilityScopes: Option = Option("-dump-availability-scopes", .flag, attributes: [.frontend, .noInteractive, .doesNotAffectIncrementalBuild], helpText: "Type-check input file(s) and dump availability scopes", group: .modes)
   public static let dumpClangDiagnostics: Option = Option("-dump-clang-diagnostics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Dump Clang diagnostics to stderr")
@@ -1197,6 +1198,7 @@ extension Option {
       Option.driverVerifyFineGrainedDependencyGraphAfterEveryImport,
       Option.driverWarnUnusedOptions,
       Option.dumpApiPath,
+      Option.dumpAstFormat,
       Option.dumpAst,
       Option.dumpAvailabilityScopes,
       Option.dumpClangDiagnostics,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5325,6 +5325,17 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testDumpASTFormat() throws {
+    var driver = try Driver(args: [
+      "swiftc", "-dump-ast", "-dump-ast-format", "json", "foo.swift"
+    ])
+    let plannedJobs = try driver.planBuild()
+    XCTAssertEqual(plannedJobs[0].kind, .compile)
+    XCTAssertTrue(plannedJobs[0].commandLine.contains("-dump-ast"))
+    XCTAssertTrue(plannedJobs[0].commandLine.contains("-dump-ast-format"))
+    XCTAssertTrue(plannedJobs[0].commandLine.contains("json"))
+  }
+
   func testDeriveSwiftDocPath() throws {
     var driver = try Driver(args: [
       "swiftc", "-emit-module", "/tmp/main.swift", "-emit-module-path", "test-ios-macabi.swiftmodule"


### PR DESCRIPTION
Cherry-pick of #1722.

* **Explanation:** Allows users to pass `-dump-ast-format` to the new driver.

* **Main Branch PR:** https://github.com/swiftlang/swift-driver/pull/1722

* **Risk: Very Low**

* **Reviewed By:** @artemcm

* **Testing:** Added new tests to the test suite.
