### PR TITLE
Exclude `swift-autolink-extractor` no-op job for embedded Wasm

### DIFF
--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -19,7 +19,7 @@ import struct TSCBasic.RelativePath
 extension Driver {
   /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
       switch targetTriple.objectFormat {
-      case .wasm where targetTriple.os != .noneOS:
+      case .wasm where !parsedOptions.isEmbeddedEnabled:
           fallthrough
 
       case .elf:

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -18,16 +18,18 @@ import struct TSCBasic.RelativePath
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
   /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
+    mutating get {
       switch targetTriple.objectFormat {
       case .wasm where !parsedOptions.isEmbeddedEnabled:
-          fallthrough
+        fallthrough
 
       case .elf:
-          return lto == nil && linkerOutputType != nil
+        return lto == nil && linkerOutputType != nil
 
       default:
-          return false
+        return false
       }
+    }
   }
 
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -18,8 +18,16 @@ import struct TSCBasic.RelativePath
 // FIXME: Also handle Cygwin and MinGW
 extension Driver {
   /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
-    [.elf, .wasm].contains(targetTriple.objectFormat) && lto == nil &&
-    linkerOutputType != nil
+      switch targetTriple.objectFormat {
+      case .wasm where targetTriple.os == .wasi:
+          fallthrough
+
+      case .elf:
+          return lto == nil && linkerOutputType != nil
+
+      default:
+          return false
+      }
   }
 
   mutating func autolinkExtractJob(inputs: [TypedVirtualPath]) throws -> Job? {

--- a/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
+++ b/Sources/SwiftDriver/Jobs/AutolinkExtractJob.swift
@@ -19,7 +19,7 @@ import struct TSCBasic.RelativePath
 extension Driver {
   /*@_spi(Testing)*/ public var isAutolinkExtractJobNeeded: Bool {
       switch targetTriple.objectFormat {
-      case .wasm where targetTriple.os == .wasi:
+      case .wasm where targetTriple.os != .noneOS:
           fallthrough
 
       case .elf:

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6799,10 +6799,9 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "-target", "wasm32-none-none-wasm", "test.swift", "-enable-experimental-feature", "Embedded", "-wmo", "-o", "a.wasm"], env: env)
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 3)
+      XCTAssertEqual(plannedJobs.count, 2)
       let compileJob = plannedJobs[0]
-      let _ /*autolinkJob*/ = plannedJobs[1]
-      let linkJob = plannedJobs[2]
+      let linkJob = plannedJobs[1]
       XCTAssertJobInvocationMatches(compileJob, .flag("-disable-objc-interop"))
       XCTAssertFalse(linkJob.commandLine.contains(.flag("-force_load")))
       XCTAssertFalse(linkJob.commandLine.contains(.flag("-rpath")))
@@ -6813,9 +6812,8 @@ final class SwiftDriverTests: XCTestCase {
     do {
       var driver = try Driver(args: ["swiftc", "-target", "wasm32-none-none-wasm", "test.o", "-enable-experimental-feature", "Embedded", "-wmo", "-o", "a.wasm"], env: env)
       let plannedJobs = try driver.planBuild()
-      XCTAssertEqual(plannedJobs.count, 2)
-      let _ /*autolinkJob*/ = plannedJobs[0]
-      let linkJob = plannedJobs[1]
+      XCTAssertEqual(plannedJobs.count, 1)
+      let linkJob = plannedJobs[0]
       XCTAssertFalse(linkJob.commandLine.contains(.flag("-force_load")))
       XCTAssertFalse(linkJob.commandLine.contains(.flag("-rpath")))
       XCTAssertFalse(linkJob.commandLine.contains(.flag("-lswiftCore")))


### PR DESCRIPTION
This driver job has no effect (all autolinking sections are empty when building in this mode) and is actually prone to failure when Wasm reference types are used:

```
error: autolink-extract command failed with exit code 1 (use -v to see invocation)
.build/wasm32-unknown-none-wasm/release/externref.build/externref.c.o' (invalid data relocation: table)
```