### PR TITLE
[BridgingHeader] Pass bridging header chaining flag for all jobs

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -338,6 +338,10 @@ public struct Driver {
   /// Original ObjC Header passed from command-line
   let originalObjCHeaderFile: VirtualPath.Handle?
 
+
+  /// Enable bridging header chaining.
+  let bridgingHeaderChaining: Bool
+
   /// The path to the imported Objective-C header.
   lazy var importedObjCHeader: VirtualPath.Handle? = {
     assert(explicitDependencyBuildPlanner != nil ||
@@ -1124,6 +1128,19 @@ public struct Driver {
       self.originalObjCHeaderFile = try? VirtualPath.intern(path: objcHeaderPathArg.asSingle)
     } else {
       self.originalObjCHeaderFile = nil
+    }
+
+    if parsedOptions.hasFlag(positive: .autoBridgingHeaderChaining,
+                             negative: .noAutoBridgingHeaderChaining,
+                             default: false) || cachingEnabled {
+      if producePCHJob {
+        self.bridgingHeaderChaining = true
+      } else {
+        diagnosticEngine.emit(.warning("-auto-bridging-header-chaining requires generatePCH job, no chaining will be performed"))
+        self.bridgingHeaderChaining = false
+      }
+    } else {
+      self.bridgingHeaderChaining = false
     }
 
     self.useClangIncludeTree = !parsedOptions.hasArgument(.noClangIncludeTree) && !env.keys.contains("SWIFT_CACHING_USE_CLANG_CAS_FS")

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -495,6 +495,15 @@ extension Driver {
       }
     }
 
+    // Pass bridging header chaining options.
+    if isFrontendArgSupported(.autoBridgingHeaderChaining) {
+      if bridgingHeaderChaining {
+        commandLine.appendFlag(.autoBridgingHeaderChaining)
+      } else {
+        commandLine.appendFlag(.noAutoBridgingHeaderChaining)
+      }
+    }
+
     // Pass along -no-verify-emitted-module-interface only if it's effective.
     // Assume verification by default as we want to know only when the user skips
     // the verification.

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -464,7 +464,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       guard driver.isFrontendArgSupported(.autoBridgingHeaderChaining) else { return }
 
       // Warn if -disable-bridging-pch is used with auto bridging header chaining.
-      driver = try Driver(args: ["swiftc", "-v",
+      driver = try Driver(args: ["swiftc",
                                  "-I", FooInstallPath.nativePathString(escaped: true),
                                  "-explicit-module-build", "-auto-bridging-header-chaining", "-disable-bridging-pch",
                                  "-pch-output-dir", FooInstallPath.nativePathString(escaped: true),


### PR DESCRIPTION
Pass `-auto-bridging-header-chaining` to all planned jobs. The module importing job relies on the flag to know not to import bridging header from binary modules because they are available chained in PCH file.