### PR TITLE
[Test] Fix a typo in the JobExecutorTests

### DIFF
--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -351,7 +351,7 @@ final class JobExecutorTests: XCTestCase {
       let main = path.appending(component: "main.swift")
       try localFileSystem.writeFileContents(main, bytes: "let foo = 1")
 
-      var driver = try Driver(args: ["swift", main.pathString])
+      var driver = try Driver(args: ["swiftc", main.pathString])
       let jobs = try driver.planBuild()
       XCTAssertEqual(jobs.count, 1)
       XCTAssertTrue(jobs[0].requiresInPlaceExecution)


### PR DESCRIPTION
There is a typo in "testInputModifiedDuringMultiJobBuild" that calls `swift` instead of `swiftc`. This drops swift into interactive mode and can cause the entire test suite to return 0 on linux even there are other errors.