### PR TITLE
[Tests] Fix another early termination in tests

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -720,13 +720,13 @@ final class CachingBuildTests: XCTestCase {
                               interModuleDependencyOracle: dependencyOracle)
       let jobs = try driver.planBuild()
       for job in jobs {
-          XCTAssertFalse(job.outputCacheKeys.isEmpty)
+        XCTAssertFalse(job.outputCacheKeys.isEmpty)
       }
-      if driver.isFrontendArgSupported(.importPch) {
-          XCTAssertTrue(jobs.contains { $0.kind == .generatePCH })
+      if driver.isFrontendArgSupported(.autoBridgingHeaderChaining) {
+        XCTAssertTrue(jobs.contains { $0.kind == .generatePCH })
+        try driver.run(jobs: jobs)
+        XCTAssertFalse(driver.diagnosticEngine.hasErrors)
       }
-      try driver.run(jobs: jobs)
-      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
     }
   }
 


### PR DESCRIPTION
When running swift-driver test suite with an older compiler that doesn't support bridging header chaining, the second part of the bridging header caching test will just be a single job, from which the default executor will run the swift-frontend in-place. This will cause the test suite to early exit regardless of the state of the test suite.