### PR TITLE
[Caching] Change SDK prefix mapping to parent directory

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -296,7 +296,9 @@ public struct Driver {
       }
       if let sdkMapping = scannerPrefixMapSDK,
          let sdkPath = absoluteSDKPath {
-        mapping.append((sdkPath, sdkMapping))
+        // Remap the parent directory of the SDK path because some compiler
+        // relies on the name of the SDK to make decisions.
+        mapping.append((sdkPath.parentDirectory, sdkMapping))
       }
       if let toolchainMapping = scannerPrefixMapToolchain {
         let toolchainPath = try toolchain.executableDir.parentDirectory // usr


### PR DESCRIPTION
Change the prefix mapping of the SDK to the parent path of the actualy SDK path. This preserves the SDK name in the path so tools can make assumption with the name to infer informations if needed.

rdar://144886542