### PR TITLE
Revert #1804

### DIFF
--- a/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/Toolchain+LinkerSupport.swift
@@ -32,14 +32,8 @@ extension Toolchain {
     if platform == "android" {
       platform = "linux"
     }
-
-    // NOTE(compnerd) Windows uses the per-target runtime directory for the
-    // Windows runtimes. This should also be done for the other platforms, but
-    // is not critical. This is done to allow for the Windows runtimes to be
-    // co-located for all the currently supported architectures: x86, x64, arm64.
-    let bIsWindows = targetInfo.target.triple.isWindows
     return VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-      .appending(components: "clang", "lib", bIsWindows ? targetInfo.target.triple.triple : platform)
+      .appending(components: "clang", "lib", platform)
   }
 
   func runtimeLibraryPaths(

--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -223,10 +223,7 @@ extension WindowsToolchain {
       commandLine.appendFlag(optArg)
     }
 
-    if !sanitizers.isEmpty {
-      let sanitize = sanitizers.map(\.rawValue).sorted().joined(separator: ",")
-      commandLine.appendFlag("-fsanitize=\(sanitize)")
-    }
+    // FIXME(compnerd) render asan/ubsan runtime link for executables
 
     if parsedOptions.contains(.profileGenerate) {
       assert(bForceLLD,

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -130,11 +130,6 @@ extension WindowsToolchain.ToolchainValidationError {
   public func runtimeLibraryName(for sanitizer: Sanitizer, targetTriple: Triple,
                                  isShared: Bool) throws -> String {
     // TODO(compnerd) handle shared linking
-
-    // FIXME(compnerd) when should `clang_rt.ubsan_standalone_cxx` be used?
-    if sanitizer == .undefinedBehavior {
-      return "clang_rt.ubsan_standalone.lib"
-    }
     return "clang_rt.\(sanitizer.libraryName).lib"
   }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2758,7 +2758,6 @@ final class SwiftDriverTests: XCTestCase {
     }
 #endif
 
-  #if os(macOS) || os(Windows)
     do {
       // undefined behavior sanitizer
       var driver = try Driver(args: commonArgs + ["-sanitize=undefined"])
@@ -2817,7 +2816,6 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertTrue(linkCmd.contains(.flag("-fsanitize=scudo")))
     }
     #endif
-  #endif
 
   // FIXME: This test will fail when not run on Android, because the driver uses
   //        the existence of the runtime support libraries to determine if


### PR DESCRIPTION
Even after https://github.com/swiftlang/swift-driver/pull/1814, https://github.com/swiftlang/swift-driver/pull/1804 is still breaking Linux CI so revert it for now.