### PR TITLE
[Unix] Use the new `-sysroot` flag for all non-Darwin Unix platforms, not just Android (#1811)

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -217,14 +217,14 @@ extension GenericUnixToolchain {
         commandLine.appendPath(try VirtualPath(path: opt.argument.asSingle))
       }
 
-      if targetTriple.environment == .android {
-        if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
-          commandLine.appendFlag("--sysroot")
-          try commandLine.appendPath(VirtualPath(path: sysroot))
-        } else if let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env) {
-          commandLine.appendFlag("--sysroot")
-          try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
-        }
+      if let sysroot = parsedOptions.getLastArgument(.sysroot)?.asSingle {
+        commandLine.appendFlag("--sysroot")
+        try commandLine.appendPath(VirtualPath(path: sysroot))
+      } else if targetTriple.environment == .android,
+        let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env)
+      {
+        commandLine.appendFlag("--sysroot")
+        try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
       } else if let path = targetInfo.sdkPath?.path {
         commandLine.appendFlag("--sysroot")
         commandLine.appendPath(VirtualPath.lookup(path))

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -152,14 +152,14 @@ public final class GenericUnixToolchain: Toolchain {
     frontendTargetInfo: FrontendTargetInfo,
     driver: inout Driver
   ) throws {
-    if driver.targetTriple.environment == .android {
-      if let sysroot = driver.parsedOptions.getLastArgument(.sysroot)?.asSingle {
-        commandLine.appendFlag("-sysroot")
-        try commandLine.appendPath(VirtualPath(path: sysroot))
-      } else if let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env) {
-        commandLine.appendFlag("-sysroot")
-        try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
-      }
+    if let sysroot = driver.parsedOptions.getLastArgument(.sysroot)?.asSingle {
+      commandLine.appendFlag("-sysroot")
+      try commandLine.appendPath(VirtualPath(path: sysroot))
+    } else if driver.targetTriple.environment == .android,
+      let sysroot = AndroidNDK.getDefaultSysrootPath(in: self.env)
+    {
+      commandLine.appendFlag("-sysroot")
+      try commandLine.appendPath(VirtualPath(path: sysroot.pathString))
     }
   }
 }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -8149,7 +8149,7 @@ final class SwiftDriverTests: XCTestCase {
       do {
         let sysroot = path.appending(component: "sysroot")
         var driver = try Driver(args: [
-          "swiftc", "-target", "aarch64-unknown-linux-android", "-sysroot", sysroot.pathString, #file
+          "swiftc", "-target", "aarch64-unknown-linux-gnu", "-sysroot", sysroot.pathString, #file
         ], env: env)
         let jobs = try driver.planBuild().removingAutolinkExtractJobs()
         let frontend = try XCTUnwrap(jobs.first)


### PR DESCRIPTION
__Explanation:__ This makes two changes:

1. Use the new flag on all Unix platforms, as in the original frontend pull where it was introduced, swiftlang/swift#72352.
2. When compiling for Android and `ANDROID_NDK_ROOT` is unset, fall back to the `-sdk` as the sysroot when linking.

I'm primarily concerned with 2., as it got a few packages cross-compiling again with both my trunk and 6.1 Android SDK bundles, but I went ahead and updated 1. also, when I looked into how that new `-sysroot` flag was introduced in that linked compiler frontend pull.

__Scope:__ Only affects Unix platforms and Android

__Issue:__ None

__Original PR:__ #1811

__Risk:__ Very low

__Testing:__ Passed all CI on trunk and appears to fix getting my Android SDK bundle working with this new swift-driver again, because of 2.

__Reviewer:__ @compnerd