### PR TITLE
[SDK Support] Make sure to look in `swift_static` rather than just `swift`.

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -171,7 +171,13 @@ extension GenericUnixToolchain {
         let rsrc: VirtualPath
         // Prefer the swiftrt.o runtime file from the SDK if it's specified.
         if let sdk = targetInfo.sdkPath {
-          rsrc = VirtualPath.lookup(sdk.path).appending(components: "usr", "lib", "swift")
+          let swiftDir: String
+          if staticStdlib || staticExecutable {
+            swiftDir = "swift_static"
+          } else {
+            swiftDir = "swift"
+          }
+          rsrc = VirtualPath.lookup(sdk.path).appending(components: "usr", "lib", swiftDir)
         } else {
           rsrc = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
         }


### PR DESCRIPTION
If we're building a statically linked executable, we should look in `usr/lib/swift_static` for `swiftrt.o`, rather than looking in `usr/lib/swift`.  Not doing this breaks the Static SDK for Linux.

rdar://145549541