### PR TITLE
[Unix] Go back to checking the runtime resource path for swiftrt.o if `-sysroot` unspecified

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -187,22 +187,13 @@ extension GenericUnixToolchain {
       }
 
       if !isEmbeddedEnabled && !parsedOptions.hasArgument(.nostartfiles) {
-        let rsrc: VirtualPath
-        // Prefer the swiftrt.o runtime file from the SDK if it's specified.
-        if let sdk = targetInfo.sdkPath {
-          let swiftDir: String
-          if staticStdlib || staticExecutable {
-            swiftDir = "swift_static"
-          } else {
-            swiftDir = "swift"
-          }
-          rsrc = VirtualPath.lookup(sdk.path).appending(components: "usr", "lib", swiftDir)
-        } else {
-          rsrc = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-        }
-        let platform: String = targetTriple.platformName() ?? ""
-        let architecture: String = majorArchitectureName(for: targetTriple)
-        commandLine.appendPath(rsrc.appending(components: platform, architecture, "swiftrt.o"))
+        let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+          .appending(
+            components: targetTriple.platformName() ?? "",
+            String(majorArchitectureName(for: targetTriple)),
+            "swiftrt.o"
+          )
+        commandLine.appendPath(swiftrtPath)
       }
 
       // If we are linking statically, we need to add all

--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -187,13 +187,23 @@ extension GenericUnixToolchain {
       }
 
       if !isEmbeddedEnabled && !parsedOptions.hasArgument(.nostartfiles) {
-        let swiftrtPath = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
-          .appending(
-            components: targetTriple.platformName() ?? "",
-            String(majorArchitectureName(for: targetTriple)),
-            "swiftrt.o"
-          )
-        commandLine.appendPath(swiftrtPath)
+        let rsrc: VirtualPath
+        // Prefer the swiftrt.o runtime file from the SDK, if it's specified
+        // with a separate C/C++ sysroot.
+        if let sdk = targetInfo.sdkPath, parsedOptions.hasArgument(.sysroot) {
+          let swiftDir: String
+          if staticStdlib || staticExecutable {
+            swiftDir = "swift_static"
+          } else {
+            swiftDir = "swift"
+          }
+          rsrc = VirtualPath.lookup(sdk.path).appending(components: "usr", "lib", swiftDir)
+        } else {
+          rsrc = VirtualPath.lookup(targetInfo.runtimeResourcePath.path)
+        }
+        let platform: String = targetTriple.platformName() ?? ""
+        let architecture: String = majorArchitectureName(for: targetTriple)
+        commandLine.appendPath(rsrc.appending(components: platform, architecture, "swiftrt.o"))
       }
 
       // If we are linking statically, we need to add all

--- a/Tests/SwiftDriverTests/ToolchainTests.swift
+++ b/Tests/SwiftDriverTests/ToolchainTests.swift
@@ -485,18 +485,13 @@ import CRT
 
   @Test func relativeResourceDir() async throws {
     do {
-      // Reset the environment to avoid 'SDKROOT' influencing the
-      // linux driver paths and taking the priority over the resource directory.
-      var env = ProcessEnv.block
-      env["SDKROOT"] = nil
       var driver = try TestDriver(
         args: [
           "swiftc",
           "-target", "x86_64-unknown-linux", "-lto=llvm-thin",
           "foo.swift",
           "-resource-dir", "resource/dir",
-        ],
-        env: env
+        ]
       )
       let plannedJobs = try await driver.planBuild().removingAutolinkExtractJobs()
 
@@ -518,7 +513,7 @@ import CRT
     }
   }
 
-  @Test func sdkDirLinuxPrioritizedOverRelativeResourceDirForLinkingSwiftRT() async throws {
+  @Test func RelativeResourceDirLinuxPrioritizedOverSDKDirForLinkingSwiftRT() async throws {
     do {
       let sdkRoot = try testInputsPath.appending(component: "mock-sdk.sdk")
       var env = ProcessEnv.block
@@ -539,7 +534,7 @@ import CRT
       #expect(linkJob.kind == .link)
       try expectJobInvocationMatches(
         linkJob,
-        toPathOption(sdkRoot.pathString + "/usr/lib/swift/linux/x86_64/swiftrt.o", isRelative: false)
+        toPathOption("resource/dir/linux/x86_64/swiftrt.o")
       )
     }
   }


### PR DESCRIPTION
This is made possible by the swift-frontend now setting this instead in swiftlang/swift#79621. More changes incoming...