### PR TITLE
Rename env var with more accurate name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTPM_MACOS_DEP
     macOSPlatform = .macOS(.v12)
 }
 
-let swiftToolsSupportCoreLibName = (ProcessInfo.processInfo.environment["SWIFTPM_SWBUILD_FRAMEWORK"] == nil) ? "SwiftToolsSupport-auto": "SwiftToolsSupport"
+let swiftToolsSupportCoreLibName = (ProcessInfo.processInfo.environment["SWIFT_DRIVER_USE_STSC_DYLIB"] == nil) ? "SwiftToolsSupport-auto": "SwiftToolsSupport"
 
 let package = Package(
   name: "swift-driver",


### PR DESCRIPTION
The SWIFTPM_SWBUILD_FRAMEWORK environment variable used in the Package.swift is not indicative of the actual behaviour.

Rename the environment variable to SWIFT_DRIVER_USE_STSC_DYLIB to more clearly indicate the behavioural change when it is set.