### PR TITLE
[PCH][OutputFileMap] GeneratePCH output should use single output entry

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -3133,8 +3133,7 @@ extension Driver {
   func computePrecompiledBridgingHeaderDir(
     _ parsedOptions: inout ParsedOptions,
     compilerMode: CompilerMode) throws -> VirtualPath? {
-    if let input = originalObjCHeaderFile,
-       let outputPath = try? outputFileMap?.existingOutput(inputFile: input, outputType: .pch) {
+    if let outputPath = try? outputFileMap?.existingOutputForSingleInput(outputType: .pch) {
       return VirtualPath.lookup(outputPath).parentDirectory
     }
     if let outputDir = parsedOptions.getLastArgument(.pchOutputDir)?.asSingle {
@@ -3154,7 +3153,7 @@ extension Driver {
         return nil
     }
 
-    if let outputPath = try? outputFileMap?.existingOutput(inputFile: input, outputType: .pch) {
+    if let outputPath = try? outputFileMap?.existingOutputForSingleInput(outputType: .pch) {
       return outputPath
     }
 


### PR DESCRIPTION
The build system has been emitting the output path of generating PCH job in the module level entry in the output file map, while swift-driver is expecting the entry in an entry that accosiated with imported bridging header.

This patch unifies the behavior by picking the implementation of the swift-build, where it is a module level entry. This works better for future when bridging header can be chained, thus creating PCH job even there isn't a imported objc header explicitly provided.

rdar://146395316