### PR TITLE
[Explain Dependency] Fix performance bug in `-explain-module-dependency` implementation

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/CommonDependencyOperations.swift
@@ -424,7 +424,8 @@ internal extension InterModuleDependencyGraph {
     }
 
     for dependency in allDependencies {
-      if try findAPath(source: dependency,
+      if !visited.contains(dependency),
+         try findAPath(source: dependency,
                        pathSoFar: pathSoFar + [dependency],
                        visited: &visited,
                        result: &result,


### PR DESCRIPTION
Embarrassingly, the code failed to query the already-`visited` set when traversing dependencies.