### PR TITLE
Allow module aliases to be raw identifiers.

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2973,8 +2973,10 @@ extension Driver {
                                      with moduleName: String,
                                      onError diagnosticsEngine: DiagnosticsEngine) -> [String: String]? {
     var moduleAliases: [String: String]? = nil
-    let validate = { (_ arg: String, allowModuleName: Bool) -> Bool in
-      if !arg.sd_isSwiftIdentifier {
+    // validatingModuleName should be true when validating the alias target (an actual module
+    // name), or false when validating the alias name (which can be a raw identifier).
+    let validate = { (_ arg: String, validatingModuleName: Bool) -> Bool in
+      if (validatingModuleName && !arg.sd_isSwiftIdentifier) || !arg.sd_isValidAsRawIdentifier {
         diagnosticsEngine.emit(.error_bad_module_name(moduleName: arg, explicitModuleName: true))
         return false
       }
@@ -2982,7 +2984,7 @@ extension Driver {
         diagnosticsEngine.emit(.error_stdlib_module_name(moduleName: arg, explicitModuleName: true))
         return false
       }
-      if !allowModuleName, arg == moduleName {
+      if !validatingModuleName, arg == moduleName {
         diagnosticsEngine.emit(.error_bad_module_alias(arg, moduleName: moduleName))
         return false
       }

--- a/Tests/SwiftDriverTests/StringAdditionsTests.swift
+++ b/Tests/SwiftDriverTests/StringAdditionsTests.swift
@@ -76,4 +76,16 @@ final class StringAdditionsTests: XCTestCase {
         XCTAssertFalse("".sd_isSwiftIdentifier,
                        "Private-use characters aren't valid Swift identifiers")
     }
+
+    func testRawIdentifiers() {
+        XCTAssertTrue("plain".sd_isValidAsRawIdentifier)
+        XCTAssertTrue("has spaces".sd_isValidAsRawIdentifier)
+        XCTAssertTrue("$^has/other!characters@#".sd_isValidAsRawIdentifier)
+
+        XCTAssertFalse("has`backtick".sd_isValidAsRawIdentifier)
+        XCTAssertFalse("has\\backslash".sd_isValidAsRawIdentifier)
+        XCTAssertFalse("has\u{0000}control\u{007F}characters".sd_isValidAsRawIdentifier)
+        XCTAssertFalse("has\u{00A0}forbidden\u{2028}whitespace".sd_isValidAsRawIdentifier)
+        XCTAssertFalse(" ".sd_isValidAsRawIdentifier)
+    }
 }


### PR DESCRIPTION
This is the companion to the frontend changes for SE-0451 in https://github.com/swiftlang/swift/pull/76636. The first component of a `-module-alias` flag is allowed to be a raw identifier (without the backticks); for example, `-module-alias //some/module:name=ActualModuleName` allows users to write this:

```
import `//some/module:name`
```

The *target* of the alias (the actual module name) must still be a valid Swift identifier, since that corresponds to file system artifacts that need stricter naming conventions.