### PR TITLE
Added a getSingleFrontendInvocationFromDriverArgumentsV3 function whi…

### DIFF
--- a/Sources/SwiftDriver/ToolingInterface/SimpleExecutor.swift
+++ b/Sources/SwiftDriver/ToolingInterface/SimpleExecutor.swift
@@ -20,20 +20,20 @@ import class TSCBasic.Process
 /// TODO: It would be nice if build planning did not involve an executor.
 /// We must hunt down all uses of an executor during planning and move
 /// relevant compiler functionality into libSwiftScan.
-internal class SimpleExecutor: DriverExecutor {
-  let resolver: ArgsResolver
+@_spi(Testing) public class SimpleExecutor: DriverExecutor {
+  public let resolver: ArgsResolver
   let fileSystem: FileSystem
   let env: [String: String]
 
-  init(resolver: ArgsResolver, fileSystem: FileSystem, env: [String: String]) {
+  public init(resolver: ArgsResolver, fileSystem: FileSystem, env: [String: String]) {
     self.resolver = resolver
     self.fileSystem = fileSystem
     self.env = env
   }
 
-  func execute(job: Job,
-               forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws -> ProcessResult {
+  public func execute(job: Job,
+                      forceResponseFiles: Bool,
+                      recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws -> ProcessResult {
     let arguments: [String] = try resolver.resolveArgumentList(for: job,
                                                                useResponseFiles: .heuristic)
     var childEnv = env
@@ -42,17 +42,17 @@ internal class SimpleExecutor: DriverExecutor {
     return try process.waitUntilExit()
   }
 
-  func execute(workload: DriverExecutorWorkload, delegate: JobExecutionDelegate,
-               numParallelJobs: Int, forceResponseFiles: Bool,
-               recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws {
+  public func execute(workload: DriverExecutorWorkload, delegate: JobExecutionDelegate,
+                      numParallelJobs: Int, forceResponseFiles: Bool,
+                      recordedInputModificationDates: [TypedVirtualPath : TimePoint]) throws {
     fatalError("Unsupported operation on current executor")
   }
 
-  func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
+  public func checkNonZeroExit(args: String..., environment: [String : String]) throws -> String {
     try Process.checkNonZeroExit(arguments: args, environment: environment)
   }
 
-  func description(of job: Job, forceResponseFiles: Bool) throws -> String {
+  public func description(of job: Job, forceResponseFiles: Bool) throws -> String {
     let useResponseFiles : ResponseFileHandling = forceResponseFiles ? .forced : .heuristic
     let (args, usedResponseFile) = try resolver.resolveArgumentList(for: job, useResponseFiles: useResponseFiles)
     var result = args.map { $0.spm_shellEscaped() }.joined(separator: " ")

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -16,7 +16,7 @@ import XCTest
 import CToolingTestShim
 
 final class SwiftDriverToolingInterfaceTests: XCTestCase {
-  func testCreateCompilerInvocation() throws {
+  func testCreateCompilerInvocationV2() throws {
     try withTemporaryDirectory { path in
       let inputFile = path.appending(components: "test.swift")
       try localFileSystem.writeFileContents(inputFile) { $0.send("public func foo()") }
@@ -92,6 +92,100 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
       }
     }
   }
+
+  func testCreateCompilerInvocationV3() throws {
+    try withTemporaryDirectory { path in
+      let inputFile = path.appending(components: "test.swift")
+      try localFileSystem.writeFileContents(inputFile) { $0.send("public func foo()") }
+
+      let env = ProcessEnv.vars
+      let resolver = try ArgsResolver(fileSystem: localFileSystem)
+      let executor = SimpleExecutor(resolver: resolver, fileSystem: localFileSystem, env: env)
+
+      // Expected success scenarios:
+      do {
+        let testCommand = inputFile.description
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in },
+                                                                        env: env,
+                                                                        executor: executor))
+      }
+      do {
+        let testCommand = "-emit-executable " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header -o t.out"
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in },
+                                                                        env: env,
+                                                                        executor: executor))
+      }
+      do {
+        let testCommand = "-c " + inputFile.description + " main.swift lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header"
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in },
+                                                                        env: env,
+                                                                        executor: executor))
+      }
+      do {
+        let testCommand = inputFile.description + " -enable-batch-mode"
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { _ in false },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in },
+                                                                        env: env,
+                                                                        executor: executor))
+      }
+      do { // Force no outputs
+        let testCommand = "-module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
+        var resultingFrontendArgs: [String] = []
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
+                                                                        argList: testCommand.components(separatedBy: " "),
+                                                                        action: { args in
+                                                                          resultingFrontendArgs = args
+                                                                          return false
+                                                                        },
+                                                                        diagnostics: &emittedDiagnostics,
+                                                                        diagnosticCallback: {_,_ in },
+                                                                        env: env,
+                                                                        executor: executor,
+                                                                        forceNoOutputs: true))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-module-interface-path"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-objc-header"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-objc-header-path"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-module-path"))
+        XCTAssertFalse(resultingFrontendArgs.contains("-emit-tbd-path"))
+      }
+
+      // Expected failure scenarios:
+      do {
+        let testCommand = "-v" // No inputs
+        var emittedDiagnostics: [Diagnostic] = []
+        XCTAssertTrue(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
+                                                                       argList: testCommand.components(separatedBy: " "),
+                                                                       action: { _ in false },
+                                                                       diagnostics: &emittedDiagnostics,
+                                                                       diagnosticCallback: {_,_ in },
+                                                                       env: env,
+                                                                       executor: executor))
+        let errorMessage = try XCTUnwrap(emittedDiagnostics.first?.message.text)
+        XCTAssertEqual(errorMessage, "unable to handle compilation, expected exactly one frontend job")
+      }
+    }
+  }
+
 
   func testCreateCompilerInvocationCAPI() throws {
     try withTemporaryDirectory { path in


### PR DESCRIPTION
…ch takes `env` and `executor` parameters (in addition to what V2 takes).

This allows clients of swift-driver which need a custom environment (e.g. to specify the path to libSwiftScan or swift-frontend) or which need a custom executor to get a single frontend invocation given a set of driver arguments. This commit also promotes SimpleExecutor to `@_spi(Testing) public` from `internal` so it can be used in tests of this new function.

This addresses <rdar://problem/146875054>.