### PR TITLE
Add `contains(subsequence:)` on any bidirectional sequence instead of just arrays

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -8323,7 +8323,7 @@ func assertString(
                 """, file: file, line: line)
 }
 
-extension Array where Element: Equatable {
+extension BidirectionalCollection where Element: Equatable, Index: Strideable, Index.Stride: SignedInteger {
   /// Returns true if the receiver contains the given elements as a subsequence
   /// (i.e., all elements are present, contiguous, and in the same order).
   ///
@@ -8337,10 +8337,15 @@ extension Array where Element: Equatable {
   {
     precondition(!subsequence.isEmpty,  "Subsequence may not be empty")
 
-    let subsequenceCount = subsequence.count
-    for index in 0...(self.count - subsequence.count) {
-      let subsequenceEnd = index + subsequenceCount
-      if self[index..<subsequenceEnd].elementsEqual(subsequence) {
+    guard self.count >= subsequence.count else {
+      return false
+    }
+
+    for index in self.startIndex...self.index(self.endIndex,
+                                              offsetBy: -subsequence.count) {
+      if self[index..<self.index(index,
+                                 offsetBy: subsequence.count)]
+                          .elementsEqual(subsequence) {
         return true
       }
     }

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -4182,7 +4182,7 @@ final class SwiftDriverTests: XCTestCase {
         "-emit-module-path", "target.swiftmodule",
         "-emit-variant-module-path", "variant.swiftmodule",
         "-Xfrontend", "-emit-module-doc-path", "-Xfrontend", "target.swiftdoc",
-        "-Xfrontend", "-emit-variant-module-doc-path", "variant.swiftdoc",
+        "-Xfrontend", "-emit-variant-module-doc-path", "-Xfrontend", "variant.swiftdoc",
         "-emit-module-source-info-path", "target.sourceinfo",
         "-emit-variant-module-source-info-path", "variant.sourceinfo",
         "-emit-package-module-interface-path", "target.package.swiftinterface",


### PR DESCRIPTION
Repurposing this PR for allowing `contains(subsequence:)` checks on any bidirectional collection instead of just arrays. This allows use of this check on array slices among other collections.

This PR was to originally fix an issue in passing the wrong triple to the emit-module job for the variant module. After discussion with Artem, actually fixing this issue will require a fair bit more work.

Also fixed a missing `-Xfrontend` on a test.