### PR TITLE
NFC: Create `.editorconfig` to keep formatting consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This ensures formatting with tooling that respects `.editorconfig` is consistent with the established convention in this repository.