### PR TITLE
Make a few small amendments to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,10 @@
 root = true
 
 [*]
+charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+xcode_trim_whitespace_on_empty_lines = true


### PR DESCRIPTION
Small amendment to #1840 

Be explicit about encoding and line endings, and add the extra whitespace-on-empty-lines bit needed for Xcode to behave sensibly.