### PR TITLE
[embedded] Skip checking OS versions of target triples when Embedded Swift is used

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -238,6 +238,11 @@ public final class DarwinToolchain: Toolchain {
       return
     }
 
+    // Embedded Swift should accept all target triples / OS versions / arch combinations
+    guard !parsedOptions.isEmbeddedEnabled else {
+      return
+    }
+
     // Check minimum supported OS versions. Note that Mac Catalyst falls into the iOS device case. The driver automatically uplevels the deployment target to iOS >= 13.1.
     let minVersions: [Triple.OS: (DarwinPlatform, Triple.Version)] = [
       .macosx: (.macOS, Triple.Version(10, 9, 0)),

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6880,6 +6880,13 @@ final class SwiftDriverTests: XCTestCase {
       }
     }
 
+    // 32-bit iOS jobs under Embedded should be allowed regardless of OS version
+    do {
+      try Driver(args: ["swiftc", "-c", "-target", "armv7-apple-ios8", "-enable-experimental-feature", "Embedded", "foo.swift"])
+      try Driver(args: ["swiftc", "-c", "-target", "armv7-apple-ios12.1", "-enable-experimental-feature", "Embedded", "foo.swift"])
+      try Driver(args: ["swiftc", "-c", "-target", "armv7-apple-ios16", "-enable-experimental-feature", "Embedded", "foo.swift"])
+    }
+
     do {
       let diags = DiagnosticsEngine()
       var driver = try Driver(args: ["swiftc", "-target", "arm64-apple-macosx10.13",  "test.swift", "-enable-experimental-feature", "Embedded", "-parse-as-library", "-wmo", "-o", "a.out", "-module-name", "main", "-enable-library-evolution"], diagnosticsEngine: diags)


### PR DESCRIPTION
We have a bunch of Darwin OS version checks, but those really shouldn't apply for Embedded Swift, because the OS version check logic is only for userspace binaries. Embedded Swift is meant for non-userspace firmware and other components, where these OS version numbers are meaningless.

rdar://147439906
