### PR TITLE
Ensure we don't skip precompile jobs if a planned interface verification depends on recompiling modules

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -139,9 +139,11 @@ extension IncrementalCompilationState.FirstWaveComputer {
   private func nonVerifyAfterCompileJobsDependOnBeforeCompileJobs() -> Bool {
     let beforeCompileJobOutputs = jobsInPhases.beforeCompiles.reduce(into: Set<TypedVirtualPath>(),
                                                                      { (pathSet, job) in pathSet.formUnion(job.outputs) })
-    let afterCompilesDependnigJobs = jobsInPhases.afterCompiles.filter {postCompileJob in postCompileJob.inputs.contains(where: beforeCompileJobOutputs.contains)}
-    if afterCompilesDependnigJobs.isEmpty || afterCompilesDependnigJobs.allSatisfy({ $0.kind == .verifyModuleInterface }) {
+    let afterCompilesDependingJobs = jobsInPhases.afterCompiles.filter {postCompileJob in postCompileJob.inputs.contains(where: beforeCompileJobOutputs.contains)}
+    if afterCompilesDependingJobs.isEmpty {
       return false
+    } else if afterCompilesDependingJobs.allSatisfy({ $0.kind == .verifyModuleInterface }) {
+      return jobsInPhases.beforeCompiles.contains { $0.kind == .generatePCM || $0.kind == .compileModuleFromInterface }
     } else {
       return true
     }

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -199,10 +199,12 @@ extension Driver {
     try commandLine.appendLast(.AssertConfig, from: &parsedOptions)
     try commandLine.appendLast(.autolinkForceLoad, from: &parsedOptions)
 
-    if let colorOption = parsedOptions.last(for: .colorDiagnostics, .noColorDiagnostics) {
-      commandLine.appendFlag(colorOption.option)
-    } else if shouldColorDiagnostics() {
+    if parsedOptions.hasFlag(positive: .colorDiagnostics, negative: .noColorDiagnostics, default: shouldColorDiagnostics()) {
       commandLine.appendFlag(.colorDiagnostics)
+      appendXccFlag("-fcolor-diagnostics")
+    } else {
+      commandLine.appendFlag(.noColorDiagnostics)
+      appendXccFlag("-fno-color-diagnostics")
     }
     try commandLine.appendLast(.fixitAll, from: &parsedOptions)
     try commandLine.appendLast(.warnSwift3ObjcInferenceMinimal, .warnSwift3ObjcInferenceComplete, from: &parsedOptions)


### PR DESCRIPTION
The test has a longer comment explaining the scenario this addresses, where a change in flags or environment triggers updated PCM hashes when it should have been canonicalized away as the sources don't need to recompile.

rdar://146668157