### PR TITLE
Fix a hypothetical corner case for incremental planning

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/FirstWaveComputer.swift
@@ -143,7 +143,7 @@ extension IncrementalCompilationState.FirstWaveComputer {
     if afterCompilesDependingJobs.isEmpty {
       return false
     } else if afterCompilesDependingJobs.allSatisfy({ $0.kind == .verifyModuleInterface }) {
-      return jobsInPhases.beforeCompiles.contains { $0.kind == .generatePCM || $0.kind == .compileModuleFromInterface }
+      return jobsInPhases.beforeCompiles.contains { $0.kind == .generatePCM || $0.kind == .compileModuleFromInterface || $0.kind == .emitModule }
     } else {
       return true
     }


### PR DESCRIPTION
The jobsBeforeCompile that is emitModuleSparately job should also run if the jobsAfterCompile depends on it.