### PR TITLE
Plan swiftinterface job and verify interface job together

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -69,6 +69,8 @@ extension IncrementalCompilationState {
     /// for the first wave to execute.
     /// The primaries could be other than .swift files, i.e. .sib
     let mandatoryJobsInOrder: [Job]
+
+    let jobsAfterCompiles: [Job]
   }
 }
 

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -77,7 +77,7 @@ public final class IncrementalCompilationState {
       jobsInPhases.allJobs.first(where: {$0.kind == .generatePCH}),
       &driver)
     self.mandatoryJobsInOrder = firstWave.mandatoryJobsInOrder
-    self.jobsAfterCompiles = jobsInPhases.afterCompiles
+    self.jobsAfterCompiles = firstWave.jobsAfterCompiles
   }
 
   /// Allow concurrent access to while preventing mutation of ``IncrementalCompilationState/protectedState``


### PR DESCRIPTION
    Always plan the job producing swiftinterface and verifying
    swiftinterface together. This make sure the swiftinterface exists on
    disk or in CAS when verification job is running.

    rdar://147501517