### PR TITLE
SwiftDriver: handle `-libc` on Windows

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ModuleDependencyScanning.swift
@@ -115,7 +115,7 @@ public extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .scanDependencies,
                                  bridgingHeaderHandling: .parsed,
                                  moduleDependencyGraphUse: .dependencyScan)
-    // FIXME: MSVC runtime flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     // Pass in external target dependencies to be treated as placeholder dependencies by the scanner
     if let externalTargetDetailsMap = externalTargetModuleDetailsMap,
@@ -355,7 +355,7 @@ public extension Driver {
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .scanDependencies,
                                  bridgingHeaderHandling: .parsed,
                                  moduleDependencyGraphUse: .dependencyScan)
-    // FIXME: MSVC runtime flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     // Pass on the input files
     commandLine.append(contentsOf: inputFiles.map { .path($0.file) })

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -293,8 +293,7 @@ extension Driver {
     }
 
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .compile)
-
-    // FIXME: MSVC runtime flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     if Driver.canDoCrossModuleOptimization(parsedOptions: &parsedOptions) &&
        // For historical reasons, -cross-module-optimization turns on "aggressive" CMO

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -580,6 +580,61 @@ extension Driver {
     }
   }
 
+  mutating func addRuntimeLibraryFlags(commandLine: inout [Job.ArgTemplate]) throws {
+    guard targetTriple.isWindows else { return }
+
+    enum RuntimeFlavour {
+      case MT
+      case MTd
+      case MD
+      case MDd
+    }
+
+    let option = parsedOptions.getLastArgument(.libc)
+
+    // NOTE: default to `/MD`.  This is different from `cl`'s default behaviour
+    // of `/MT` on the command line, however, Visual Studio 2015 and newer will
+    // default `/MD` as well.  Furthermore, this is far more useful of a mode
+    // since the `/MT` mode requires that everything is statically linked.
+    let runtime: RuntimeFlavour? = switch (option?.asSingle ?? "MD") {
+      case "MD", "MultiThreadedDLL", "shared-ucrt":
+        .MD
+      case "MDd", "MultiThreadedDebugDLL", "shared-debug-ucrt":
+        .MDd
+      case "MT", "MultiThreaded", "static-ucrt":
+        .MT
+      case "MTd", "MultiThreadedDebug", "static-debug-ucrt":
+        .MTd
+      default:
+        nil
+    }
+
+    guard let runtime else {
+      diagnosticEngine.emit(.error_invalid_arg_value(arg: .libc, value: option!.asSingle))
+      return
+    }
+
+    commandLine.appendFlag(.autolinkLibrary)
+    commandLine.appendFlag("oldnames")
+
+    commandLine.appendFlag(.autolinkLibrary)
+    let name = switch (runtime) {
+      case .MD: "msvcrt"
+      case .MDd: "msvcrtd"
+      case .MT: "libcmt"
+      case .MTd: "libcmtd"
+    }
+    commandLine.appendFlag(name)
+
+    commandLine.appendFlag(.Xcc)
+    commandLine.appendFlag("-D_MT")
+
+    if [.MD, .MDd].contains(runtime) {
+      commandLine.appendFlag(.Xcc)
+      commandLine.appendFlag("-D_DLL")
+    }
+  }
+
   mutating func addBridgingHeaderPCHCacheKeyArguments(commandLine: inout [Job.ArgTemplate],
                                                       pchCompileJob: Job?) throws {
     guard let pchJob = pchCompileJob, isCachingEnabled else { return }

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -36,6 +36,7 @@ extension Driver {
     } else {
       try addGeneratePCHFlags(commandLine: &commandLine, inputs: &inputs)
     }
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     // TODO: Should this just be pch output with extension changed?
     if parsedOptions.hasArgument(.serializeDiagnostics), let outputDirectory = parsedOptions.getLastArgument(.pchOutputDir)?.asSingle {

--- a/Sources/SwiftDriver/Jobs/InterpretJob.swift
+++ b/Sources/SwiftDriver/Jobs/InterpretJob.swift
@@ -28,7 +28,7 @@ extension Driver {
     }
 
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .interpret)
-    // FIXME: MSVC runtime flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     try commandLine.appendLast(.parseSil, from: &parsedOptions)
     toolchain.addLinkedLibArgs(to: &commandLine, parsedOptions: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
+++ b/Sources/SwiftDriver/Jobs/MergeModuleJob.swift
@@ -55,7 +55,7 @@ extension Driver {
     commandLine.appendFlag(.disableSilPerfOptzns)
 
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .mergeModule, bridgingHeaderHandling: .parsed)
-    // FIXME: Add MSVC runtime library flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     try addCommonModuleOptions(commandLine: &commandLine, outputs: &outputs, moduleOutputPaths: moduleOutputPaths, isMergeModule: true)
 

--- a/Sources/SwiftDriver/Jobs/ReplJob.swift
+++ b/Sources/SwiftDriver/Jobs/ReplJob.swift
@@ -16,7 +16,7 @@ extension Driver {
     var inputs: [TypedVirtualPath] = []
 
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .repl)
-    // FIXME: MSVC runtime flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     try commandLine.appendLast(.importObjcHeader, from: &parsedOptions)
     toolchain.addLinkedLibArgs(

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -36,7 +36,7 @@ extension Driver {
     commandLine.appendFlags("-frontend", "-typecheck-module-from-interface")
     try addPathArgument(interfaceInput.file, to: &commandLine)
     try addCommonFrontendOptions(commandLine: &commandLine, inputs: &inputs, kind: .verifyModuleInterface, bridgingHeaderHandling: .ignored)
-    // FIXME: MSVC runtime flags
+    try addRuntimeLibraryFlags(commandLine: &commandLine)
 
     // Output serialized diagnostics for this job, if specifically requested
     var outputs: [TypedVirtualPath] = []

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -8245,6 +8245,48 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(driver.diagnosticEngine.hasErrors)
     }
   }
+
+  func testWindowsRuntimeLibraryFlags() throws {
+    do {
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-unknown-windows-msvc", "-libc", "MD", "-use-ld=lld", "-c", "input.swift"])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .compile)
+
+      XCTAssertJobInvocationMatches(jobs[0], .flag("-autolink-library"), .flag("oldnames"), .flag("-autolink-library"), .flag("msvcrt"), .flag("-Xcc"), .flag("-D_MT"), .flag("-Xcc"), .flag("-D_DLL"))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-unknown-windows-msvc", "-use-ld=lld", "-c", "input.swift"])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .compile)
+
+      XCTAssertJobInvocationMatches(jobs[0], .flag("-autolink-library"), .flag("oldnames"), .flag("-autolink-library"), .flag("msvcrt"), .flag("-Xcc"), .flag("-D_MT"), .flag("-Xcc"), .flag("-D_DLL"))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-unknown-windows-msvc", "-libc", "MultiThreadedDLL", "-use-ld=lld", "-c", "input.swift"])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .compile)
+
+      XCTAssertJobInvocationMatches(jobs[0], .flag("-autolink-library"), .flag("oldnames"), .flag("-autolink-library"), .flag("msvcrt"), .flag("-Xcc"), .flag("-D_MT"), .flag("-Xcc"), .flag("-D_DLL"))
+    }
+
+    do {
+      var driver = try Driver(args: ["swiftc", "-target", "x86_64-unknown-windows-msvc", "-libc", "MTd", "-use-ld=lld", "-c", "input.swift"])
+      let jobs = try driver.planBuild()
+
+      XCTAssertEqual(jobs.count, 1)
+      XCTAssertEqual(jobs[0].kind, .compile)
+
+      XCTAssertJobInvocationMatches(jobs[0], .flag("-autolink-library"), .flag("oldnames"), .flag("-autolink-library"), .flag("libcmtd"), .flag("-Xcc"), .flag("-D_MT"))
+    }
+  }
 }
 
 func assertString(


### PR DESCRIPTION
Windows has a special flag `-libc` that is responsible for determining the libc variant (ABI flavour) to link against. This flag defaults to `MD` if unspecified. We did not replicate the behaviour from the C++ implementation of the Swift driver to the Swift implementation of the driver which prevented the use of the early swift-driver.