### PR TITLE
[Incremental] Track and return skipped non-compile job

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState+Extensions.swift
@@ -65,11 +65,14 @@ extension IncrementalCompilationState {
     /// incremental dependency graph and the status of the input files for this
     /// incremental build.
     let initiallySkippedCompileJobs: [TypedVirtualPath: Job]
+    /// The non-compile jobs that can be skipped given the state of the
+    /// incremental build.
+    let skippedNonCompileJobs: [Job]
     /// All of the pre-compile or compilation job (groups) known to be required
     /// for the first wave to execute.
     /// The primaries could be other than .swift files, i.e. .sib
     let mandatoryJobsInOrder: [Job]
-
+    /// The job after compilation that needs to run.
     let jobsAfterCompiles: [Job]
   }
 }

--- a/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/IncrementalCompilationState.swift
@@ -44,6 +44,9 @@ public final class IncrementalCompilationState {
   /// Jobs to run *after* the last compile, for instance, link-editing.
   public let jobsAfterCompiles: [Job]
 
+  /// The skipped non compile jobs.
+  public let skippedJobsNonCompile: [Job]
+
   public let info: IncrementalCompilationState.IncrementalDependencyAndInputSetup
 
   internal let upToDateInterModuleDependencyGraph: InterModuleDependencyGraph?
@@ -78,6 +81,7 @@ public final class IncrementalCompilationState {
       &driver)
     self.mandatoryJobsInOrder = firstWave.mandatoryJobsInOrder
     self.jobsAfterCompiles = firstWave.jobsAfterCompiles
+    self.skippedJobsNonCompile = firstWave.skippedNonCompileJobs
   }
 
   /// Allow concurrent access to while preventing mutation of ``IncrementalCompilationState/protectedState``

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -94,7 +94,7 @@ extension Driver {
     // If the jobs are batched during the incremental build, reuse the computation rather than computing the batches again.
     if let incrementalState = incrementalCompilationState {
       // For compatibility reasons, all the jobs planned will be returned, even the incremental state suggests the job is not mandatory.
-      batchedJobs = incrementalState.skippedJobs + incrementalState.mandatoryJobsInOrder + incrementalState.jobsAfterCompiles
+      batchedJobs = incrementalState.skippedJobs + incrementalState.skippedJobsNonCompile + incrementalState.mandatoryJobsInOrder + incrementalState.jobsAfterCompiles
     } else {
       batchedJobs = try formBatchedJobs(jobsInPhases.allJobs,
                                         showJobLifecycle: showJobLifecycle,

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -845,15 +845,19 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let incrementalJobs = try incrementalDriver.planBuild()
       try incrementalDriver.run(jobs: incrementalJobs)
       XCTAssertFalse(incrementalDriver.diagnosticEngine.hasErrors)
+      let state = try XCTUnwrap(incrementalDriver.incrementalCompilationState)
+      XCTAssertTrue(state.mandatoryJobsInOrder.contains { $0.kind == .emitModule })
+      XCTAssertTrue(state.jobsAfterCompiles.contains { $0.kind == .verifyModuleInterface })
 
       // TODO: emitModule job should run again if interface is deleted.
       // try localFileSystem.removeFileTree(swiftInterfaceOutput)
 
       // This should be a null build but it is actually building the main module due to the previous build of all the modules.
       var reDriver = try Driver(args: invocationArguments + ["-color-diagnostics"])
-      let reJobs = try reDriver.planBuild()
-      XCTAssertFalse(reJobs.contains { $0.kind == .emitModule })
-      XCTAssertFalse(reJobs.contains { $0.kind == .verifyModuleInterface })
+      let _ = try reDriver.planBuild()
+      let reState = try XCTUnwrap(reDriver.incrementalCompilationState)
+      XCTAssertFalse(reState.mandatoryJobsInOrder.contains { $0.kind == .emitModule })
+      XCTAssertFalse(reState.jobsAfterCompiles.contains { $0.kind == .verifyModuleInterface })
     }
   }
 


### PR DESCRIPTION
This fixes a fallout from #1829 that skipped non-compile jobs are not returned from `planBuild()` during incremental build if there are no compile jobs are being schedule from the first place. This can result into an empty list of job being returned, and `swift-build` will treat that as an error.

Now the skipped non-compile jobs are properly tracked and returned.

rdar://147874145