### PR TITLE
[CAS] Fix the async error handling for `makeGlobal()`

### DIFF
--- a/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScanCAS.swift
@@ -59,8 +59,9 @@ public final class CachedCompilation {
         } else {
           obj.callback(DependencyScanningError.casError("unknown makeGlobal error"))
         }
+      } else {
+        obj.callback(nil)
       }
-      obj.callback(nil)
     }
 
     let context = CallbackContext(self, callback)


### PR DESCRIPTION
When makeGlobal failed, it accidentally callbacks the async function twice with the second time being success case.

rdar://147955776