### PR TITLE
Detect OpenBSD opt-out of BTCFI.

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -119,6 +119,16 @@ extension GenericUnixToolchain {
         }
       }
 
+      if targetTriple.os == .openbsd && targetTriple.arch == .aarch64 {
+        let btcfiEnabled = targetInfo.target.openbsdBTCFIEnabled ?? false
+        if !btcfiEnabled {
+          commandLine.appendFlag("-Xlinker")
+          commandLine.appendFlag("-z")
+          commandLine.appendFlag("-Xlinker")
+          commandLine.appendFlag("nobtcfi")
+        }
+      }
+
       let staticStdlib = parsedOptions.hasFlag(positive: .staticStdlib,
                                                negative: .noStaticStdlib,
                                                    default: false)

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -101,6 +101,8 @@ public struct FrontendTargetInfo: Codable {
     /// Whether the Swift libraries need to be referenced in their system
     /// location (/usr/lib/swift) via rpath.
     let librariesRequireRPath: Bool
+
+    let openbsdBTCFIEnabled: Bool?
   }
 
   @_spi(Testing) public struct Paths: Codable {

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -163,12 +163,14 @@ public final class GenericUnixToolchain: Toolchain {
     }
 
     if driver.targetTriple.os == .openbsd && driver.targetTriple.arch == .aarch64 {
-      commandLine.appendFlag(.Xcc)
-      commandLine.appendFlag("-Xclang=-msign-return-address=non-leaf")
-      commandLine.appendFlag(.Xcc)
-      commandLine.appendFlag("-Xclang=-msign-return-address-key=a_key")
-      commandLine.appendFlag(.Xcc)
-      commandLine.appendFlag("-Xclang=-mbranch-target-enforce")
+      if frontendTargetInfo.target.openbsdBTCFIEnabled ?? false {
+        commandLine.appendFlag(.Xcc)
+        commandLine.appendFlag("-Xclang=-msign-return-address=non-leaf")
+        commandLine.appendFlag(.Xcc)
+        commandLine.appendFlag("-Xclang=-msign-return-address-key=a_key")
+        commandLine.appendFlag(.Xcc)
+        commandLine.appendFlag("-Xclang=-mbranch-target-enforce")
+      }
     }
   }
 }


### PR DESCRIPTION
On the swift side, we added a new build flavor in swiftlang/swift#80389 to opt-out of BTCFI as a way of working around swiftlang/swift#80059. We communicate this to swift-driver via the frontend with FrontendTargetInfo.