### PR TITLE
Android: remove build flags that are no longer needed

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -104,9 +104,6 @@ def get_swiftpm_options(args):
     if '-android' in args.build_target:
       swiftpm_args += [
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/android',
-        # SwiftPM will otherwise try to compile against GNU strerror_r on
-        # Android and fail.
-        '-Xswiftc', '-Xcc', '-Xswiftc', '-U_GNU_SOURCE',
       ]
     else:
       # Library rpath for swift, dispatch, Foundation, etc. when installing


### PR DESCRIPTION
Removing the definition of `_GNU_SOURCE` is no longer needed since swiftlang/swift-tools-support-core#500 made sure the right `strerror_r()` is used.