### PR TITLE
[Explicit Module Builds] Centralize computing *all* dependencies of a given `ModuleInfo` and use throughout

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -495,7 +495,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
                                 clangDependencyArtifacts: &clangDependencyArtifacts,
                                 swiftDependencyArtifacts: &swiftDependencyArtifacts)
       let depInfo = try dependencyGraph.moduleInfo(of: bridgingHeaderDepID)
-      dependenciesWorklist.append(contentsOf: depInfo.directDependencies ?? [])
+      dependenciesWorklist.append(contentsOf: depInfo.allDependencies)
     }
 
     // Clang module dependencies are specified on the command line explicitly

--- a/Sources/SwiftDriver/Utilities/DOTModuleDependencyGraphSerializer.swift
+++ b/Sources/SwiftDriver/Utilities/DOTModuleDependencyGraphSerializer.swift
@@ -64,10 +64,7 @@ import TSCBasic
     stream.write("digraph Modules {\n")
     for (moduleId, moduleInfo) in graph.modules {
       stream.write(outputNode(for: moduleId))
-      guard let dependencies = moduleInfo.directDependencies else {
-        continue
-      }
-      for dependencyId in dependencies {
+      for dependencyId in moduleInfo.allDependencies {
         stream.write("  \(quoteName(label(for: moduleId))) -> \(quoteName(label(for: dependencyId))) [color=black];\n")
       }
     }

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -172,7 +172,7 @@ private func checkCachingBuildJobDependencies(job: Job,
     XCTAssertTrue(job.commandLine.contains(.flag(String(cacheKey))))
   }
 
-  for dependencyId in moduleInfo.directDependencies! {
+  for dependencyId in moduleInfo.allDependencies {
     let dependencyInfo = try dependencyGraph.moduleInfo(of: dependencyId)
     switch dependencyInfo.details {
       case .swift(let swiftDependencyDetails):
@@ -186,7 +186,7 @@ private func checkCachingBuildJobDependencies(job: Job,
     }
 
     // Ensure all transitive dependencies got added as well.
-    for transitiveDependencyId in dependencyInfo.directDependencies! {
+    for transitiveDependencyId in dependencyInfo.allDependencies {
       try checkCachingBuildJobDependencies(job: job,
                                            moduleInfo: try dependencyGraph.moduleInfo(of: transitiveDependencyId),
                                            dependencyGraph: dependencyGraph)


### PR DESCRIPTION
This is in preparation of dependency scanner turning the `directDependencies` field to contain only actually-directly-imported modules.