### PR TITLE
[6.2][Caching] Fix a fallout from block list remap

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -353,7 +353,7 @@ extension Driver {
     if isFrontendArgSupported(.blockListFile) {
       try findBlocklists().forEach {
         commandLine.appendFlag(.blockListFile)
-        try addPathArgument(VirtualPath.absolute($0), to: &commandLine)
+        try addPathArgument(VirtualPath.absolute($0), to: &commandLine, remap: jobNeedPathRemap)
       }
     }
 

--- a/TestInputs/Dummy.xctoolchain/usr/local/lib/swift/blocklists/block-list1.yml
+++ b/TestInputs/Dummy.xctoolchain/usr/local/lib/swift/blocklists/block-list1.yml
@@ -1,1 +1,2 @@
 ---
+key: value

--- a/TestInputs/Dummy.xctoolchain/usr/local/lib/swift/blocklists/block-list2.yaml
+++ b/TestInputs/Dummy.xctoolchain/usr/local/lib/swift/blocklists/block-list2.yaml
@@ -1,1 +1,2 @@
 ---
+key: value

--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -901,8 +901,7 @@ final class CachingBuildTests: XCTestCase {
       var driver = try Driver(args: ["swiftc",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
-                                     "/tmp/Foo.o", "-g",
-                                     "-explicit-module-build",
+                                     "-g", "-explicit-module-build",
                                      "-cache-compile-job", "-cas-path", casPath.nativePathString(escaped: true),
                                      "-working-directory", path.nativePathString(escaped: true),
                                      "-disable-clang-target", "-scanner-prefix-map-sdk", "/^sdk",
@@ -940,6 +939,9 @@ final class CachingBuildTests: XCTestCase {
           $0.starts(with: try testInputsPath.description)
         })
       }
+
+      try driver.run(jobs: jobs)
+      XCTAssertFalse(driver.diagnosticEngine.hasErrors)
     }
   }
 


### PR DESCRIPTION
Don't remap block list path from dependency scanning invocation.

rdar://149015672