### PR TITLE
[Explicit Module Builds] Move generation of explicit auto-link flags to a toolchain-specific method

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -421,17 +421,7 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
         allLinkLibraries.append(linkLibrary)
       }
     }
-
-    for linkLibrary in allLinkLibraries {
-      if !linkLibrary.isFramework {
-        commandLine.appendFlag("-l\(linkLibrary.linkName)")
-      } else {
-        commandLine.appendFlag(.Xlinker)
-        commandLine.appendFlag("-framework")
-        commandLine.appendFlag(.Xlinker)
-        commandLine.appendFlag(linkLibrary.linkName)
-      }
-    }
+    toolchain.addAutoLinkFlags(for: allLinkLibraries, to: &commandLine)
   }
 
   /// Resolve all module dependencies of the main module and add them to the lists of

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -114,6 +114,20 @@ public final class DarwinToolchain: Toolchain {
     }
   }
 
+  public func addAutoLinkFlags(for linkLibraries: [LinkLibraryInfo], to commandLine: inout [Job.ArgTemplate]) {
+    for linkLibrary in linkLibraries {
+      if !linkLibrary.isFramework {
+        commandLine.appendFlag(.Xlinker)
+        commandLine.appendFlag("-possible-l\(linkLibrary.linkName)")
+      } else {
+        commandLine.appendFlag(.Xlinker)
+        commandLine.appendFlag("-possible_framework")
+        commandLine.appendFlag(.Xlinker)
+        commandLine.appendFlag(linkLibrary.linkName)
+      }
+    }
+  }
+
   public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
     let hostIsMacOS: Bool
     #if os(macOS)

--- a/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/GenericUnixToolchain.swift
@@ -78,6 +78,12 @@ public final class GenericUnixToolchain: Toolchain {
     }
   }
 
+  public func addAutoLinkFlags(for linkLibraries: [LinkLibraryInfo], to commandLine: inout [Job.ArgTemplate]) {
+    for linkLibrary in linkLibraries {
+      commandLine.appendFlag("-l\(linkLibrary.linkName)")
+    }
+  }
+
   /// Retrieve the absolute path for a given tool.
   public func getToolPath(_ tool: Tool) throws -> AbsolutePath {
     // Check the cache

--- a/Sources/SwiftDriver/Toolchains/Toolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/Toolchain.swift
@@ -115,6 +115,9 @@ public protocol Toolchain {
   /// Constructs a proper output file name for a linker product.
   func makeLinkerOutputFilename(moduleName: String, type: LinkOutputType) -> String
 
+  /// Adds linker flags corresponding to the specified set of link libraries
+  func addAutoLinkFlags(for linkLibraries: [LinkLibraryInfo], to commandLine: inout [Job.ArgTemplate])
+
   /// Perform platform-specific argument validation.
   func validateArgs(_ parsedOptions: inout ParsedOptions,
                     targetTriple: Triple,

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -79,6 +79,12 @@ public final class WebAssemblyToolchain: Toolchain {
     }
   }
 
+  public func addAutoLinkFlags(for linkLibraries: [LinkLibraryInfo], to commandLine: inout [Job.ArgTemplate]) {
+    for linkLibrary in linkLibraries {
+      commandLine.appendFlag("-l\(linkLibrary.linkName)")
+    }
+  }
+
   /// Retrieve the absolute path for a given tool.
   public func getToolPath(_ tool: Tool) throws -> AbsolutePath {
     // Check the cache

--- a/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WindowsToolchain.swift
@@ -113,6 +113,12 @@ extension WindowsToolchain.ToolchainValidationError {
     }
   }
 
+  public func addAutoLinkFlags(for linkLibraries: [LinkLibraryInfo], to commandLine: inout [Job.ArgTemplate]) {
+    for linkLibrary in linkLibraries {
+      commandLine.appendFlag("-l\(linkLibrary.linkName)")
+    }
+  }
+
   public func defaultSDKPath(_ target: Triple?) throws -> AbsolutePath? {
     // TODO(compnerd): replicate the SPM processing of the SDKInfo.plist
     if let SDKROOT = env["SDKROOT"] {


### PR DESCRIPTION
- This way we can adopt a feature of a specific platform's linker separately from the others.
- Adopt `-possible_l*` and `-possible_framework *` flags on Darwin platforms.