### PR TITLE
[Jobs] Add a job for `-print-supported-features`

### DIFF
--- a/Sources/SwiftDriver/CMakeLists.txt
+++ b/Sources/SwiftDriver/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(SwiftDriver
   Jobs/MergeModuleJob.swift
   Jobs/ModuleWrapJob.swift
   Jobs/Planning.swift
+  Jobs/PrintSupportedFeaturesJob.swift
   Jobs/PrintTargetInfoJob.swift
   Jobs/ReplJob.swift
   Jobs/SwiftHelpIntroJob.swift

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -98,7 +98,7 @@ extension Driver {
          .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
          .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline, .jsonABIBaseline,
          .swiftConstValues, .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo,
-         .cachedDiagnostics, nil:
+         .cachedDiagnostics, .jsonSupportedFeatures, nil:
       return false
     }
   }
@@ -487,6 +487,8 @@ extension FileType {
       return .printTargetInfo
     case .jsonCompilerFeatures:
       return .emitSupportedFeatures
+    case .jsonSupportedFeatures:
+      return .printSupportedFeatures
 
     case .swift, .dSYM, .autolink, .dependencies, .emitModuleDependencies,
          .swiftDocumentation, .pcm, .diagnostics, .emitModuleDiagnostics,

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -104,7 +104,7 @@ extension Driver {
            .help, .link, .verifyDebugInfo, .scanDependencies,
            .emitSupportedFeatures, .moduleWrap,
            .generateAPIBaseline, .generateABIBaseline, .compareAPIBaseline,
-           .compareABIBaseline:
+           .compareABIBaseline, .printSupportedFeatures:
         jobNeedPathRemap = false
       }
     } else {

--- a/Sources/SwiftDriver/Jobs/Job.swift
+++ b/Sources/SwiftDriver/Jobs/Job.swift
@@ -43,6 +43,7 @@ public struct Job: Codable, Equatable, Hashable {
     case generateABIBaseline = "generate-abi-baseline"
     case compareAPIBaseline = "compare-api-baseline"
     case compareABIBaseline = "Check ABI stability"
+    case printSupportedFeatures = "print-supported-features"
   }
 
   public enum ArgTemplate: Equatable, Hashable {
@@ -251,6 +252,9 @@ extension Job : CustomStringConvertible {
 
     case .compareABIBaseline:
       return "Comparing ABI of \(moduleName) to baseline"
+
+    case .printSupportedFeatures:
+      return "Print supported upcoming and experimental features"
     }
   }
 
@@ -270,7 +274,7 @@ extension Job.Kind {
     switch self {
     case .backend, .compile, .mergeModule, .emitModule, .compileModuleFromInterface, .generatePCH,
         .generatePCM, .dumpPCM, .interpret, .repl, .printTargetInfo,
-        .versionRequest, .emitSupportedFeatures, .scanDependencies, .verifyModuleInterface:
+        .versionRequest, .emitSupportedFeatures, .scanDependencies, .verifyModuleInterface, .printSupportedFeatures:
         return true
 
     case .autolinkExtract, .generateDSYM, .help, .link, .verifyDebugInfo, .moduleWrap,
@@ -290,7 +294,7 @@ extension Job.Kind {
          .help, .link, .verifyDebugInfo, .scanDependencies,
          .emitSupportedFeatures, .moduleWrap, .verifyModuleInterface,
          .generateAPIBaseline, .generateABIBaseline, .compareAPIBaseline,
-         .compareABIBaseline:
+         .compareABIBaseline, .printSupportedFeatures:
       return false
     }
   }
@@ -305,7 +309,7 @@ extension Job.Kind {
          .versionRequest, .autolinkExtract, .generateDSYM, .help, .link,
          .verifyDebugInfo, .scanDependencies, .emitSupportedFeatures, .moduleWrap,
          .generateAPIBaseline, .generateABIBaseline, .compareAPIBaseline,
-         .compareABIBaseline:
+         .compareABIBaseline, .printSupportedFeatures:
       return false
     }
   }

--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -713,6 +713,15 @@ extension Driver {
                                               swiftCompilerPrefixArgs: swiftCompilerPrefixArgs)
     }
 
+    if parsedOptions.hasArgument(.printSupportedFeatures) {
+      try verifyFrontendSupportsOptionIfNecessary(.printSupportedFeatures)
+
+      return try toolchain.printSupportedFeaturesJob(
+        requiresInPlaceExecution: true,
+        swiftCompilerPrefixArgs: swiftCompilerPrefixArgs
+      )
+    }
+
     if parsedOptions.hasArgument(.version) || parsedOptions.hasArgument(.version_) {
       return Job(
         moduleName: moduleOutputInfo.name,

--- a/Sources/SwiftDriver/Jobs/PrintSupportedFeaturesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintSupportedFeaturesJob.swift
@@ -1,0 +1,36 @@
+//===------- PrintSupportedFeaturesJob.swift - Swift Target Info Job ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Toolchain {
+  @_spi(Testing) public func printSupportedFeaturesJob(
+    requiresInPlaceExecution: Bool = false,
+    swiftCompilerPrefixArgs: [String]
+  ) throws -> Job {
+    var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
+    commandLine.append(contentsOf: [
+      .flag("-frontend"),
+      .flag("-print-supported-features"),
+    ])
+
+    return Job(
+      moduleName: "",
+      kind: .printSupportedFeatures,
+      tool: try resolvedTool(.swiftCompiler),
+      commandLine: commandLine,
+      displayInputs: [],
+      inputs: [],
+      primaryInputs: [],
+      outputs: [.init(file: .standardOutput, type: .jsonSupportedFeatures)],
+      requiresInPlaceExecution: requiresInPlaceExecution
+    )
+  }
+}

--- a/Sources/SwiftDriver/Utilities/FileType.swift
+++ b/Sources/SwiftDriver/Utilities/FileType.swift
@@ -117,6 +117,9 @@ public enum FileType: String, Hashable, CaseIterable, Codable {
   /// JSON-based -emit-supported-features output
   case jsonCompilerFeatures = "compilerFeatures.json"
 
+  /// JSON-based -print-supported-features output
+  case jsonSupportedFeatures = "supportedFeatures.json"
+
   /// JSON-based binary Swift module artifact description
   case jsonSwiftArtifacts = "artifacts.json"
 
@@ -271,6 +274,9 @@ extension FileType: CustomStringConvertible {
 
     case .cachedDiagnostics:
       return "cached-diagnostics"
+
+    case .jsonSupportedFeatures:
+      return "json-supported-swift-features"
     }
   }
 }
@@ -291,7 +297,8 @@ extension FileType {
          .jsonDependencies, .clangModuleMap, .jsonTargetInfo, .jsonCompilerFeatures,
          .jsonSwiftArtifacts, .indexUnitOutputPath, .modDepCache, .jsonAPIBaseline,
          .jsonABIBaseline, .swiftConstValues, .jsonAPIDescriptor,
-         .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics, .raw_llvmIr:
+         .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics, .raw_llvmIr,
+         .jsonSupportedFeatures:
       return false
     }
   }
@@ -408,6 +415,8 @@ extension FileType {
       return "module-semantic-info"
     case .cachedDiagnostics:
       return "cached-diagnostics"
+    case .jsonSupportedFeatures:
+      return "json-supported-swift-features"
     }
   }
 }
@@ -421,7 +430,7 @@ extension FileType {
          .jsonDependencies, .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo,
          .jsonSwiftArtifacts, .jsonAPIBaseline, .jsonABIBaseline, .swiftConstValues,
          .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics,
-         .raw_llvmIr:
+         .raw_llvmIr, .jsonSupportedFeatures:
       return true
     case .image, .object, .dSYM, .pch, .sib, .raw_sib, .swiftModule,
          .swiftDocumentation, .swiftSourceInfoFile, .llvmBitcode, .diagnostics,
@@ -446,7 +455,7 @@ extension FileType {
          .clangModuleMap, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSwiftArtifacts,
          .indexUnitOutputPath, .jsonAPIBaseline, .jsonABIBaseline, .swiftConstValues,
          .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics,
-         .raw_llvmIr:
+         .raw_llvmIr, .jsonSupportedFeatures:
       return false
     }
   }
@@ -454,7 +463,7 @@ extension FileType {
   /// Returns true if producing the file type requires running SILGen.
   var requiresSILGen: Bool {
     switch self {
-    case .swift, .ast, .indexData, .indexUnitOutputPath, .jsonCompilerFeatures, .jsonTargetInfo:
+    case .swift, .ast, .indexData, .indexUnitOutputPath, .jsonCompilerFeatures, .jsonTargetInfo, .jsonSupportedFeatures:
       return false
     case .sil, .sib, .image, .object, .dSYM, .dependencies, .autolink, .swiftModule, .swiftDocumentation, .swiftInterface, .privateSwiftInterface, .packageSwiftInterface, .swiftSourceInfoFile, .swiftConstValues, .assembly, .raw_sil, .raw_sib, .llvmIR, .llvmBitcode, .diagnostics, .emitModuleDiagnostics, .emitModuleDependencies, .objcHeader, .swiftDeps, .modDepCache, .remap, .importedModules, .tbd, .jsonDependencies, .jsonSwiftArtifacts, .moduleTrace, .yamlOptimizationRecord, .bitstreamOptimizationRecord, .pcm, .pch, .clangModuleMap, .jsonAPIBaseline, .jsonABIBaseline, .jsonAPIDescriptor, .moduleSummary, .moduleSemanticInfo, .cachedDiagnostics, .raw_llvmIr:
       return true
@@ -469,7 +478,7 @@ extension FileType {
          .jsonSwiftArtifacts, .remap, .indexUnitOutputPath, .modDepCache,
          // the remaining should not be an output from a caching swift job.
          .swift, .image, .dSYM, .importedModules, .clangModuleMap,
-         .jsonCompilerFeatures, .jsonTargetInfo, .autolink:
+         .jsonCompilerFeatures, .jsonTargetInfo, .autolink, .jsonSupportedFeatures:
       return false
     case .assembly, .llvmIR, .llvmBitcode, .object, .sil, .sib, .ast,
          .dependencies, .emitModuleDependencies, .swiftModule,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -763,6 +763,7 @@ extension Option {
   public static let printModule_: Option = Option("--print-module", .flag, alias: Option.printModule, attributes: [.noDriver], helpText: "Print module names in diagnostics")
   public static let printPreprocessedExplicitDependencyGraph: Option = Option("-print-preprocessed-explicit-dependency-graph", .flag, attributes: [.helpHidden], helpText: "Print the result of module dependency scanning to output")
   public static let printStats: Option = Option("-print-stats", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Print various statistics")
+  public static let printSupportedFeatures: Option = Option("-print-supported-features", .flag, attributes: [.frontend], metaVar: "<features>", helpText: "Print information about features supported by the compiler")
   public static let printTargetInfo: Option = Option("-print-target-info", .flag, attributes: [.frontend], metaVar: "<triple>", helpText: "Print target information for the given target <triple>, such as x86_64-apple-macos10.9")
   public static let printZeroStats: Option = Option("-print-zero-stats", .flag, attributes: [.helpHidden, .frontend], helpText: "Prints all stats even if they are zero")
   public static let profileCoverageMapping: Option = Option("-profile-coverage-mapping", .flag, attributes: [.frontend, .noInteractive], helpText: "Generate coverage data for use with profiled execution counts")
@@ -1720,6 +1721,7 @@ extension Option {
       Option.printModule_,
       Option.printPreprocessedExplicitDependencyGraph,
       Option.printStats,
+      Option.printSupportedFeatures,
       Option.printTargetInfo,
       Option.printZeroStats,
       Option.profileCoverageMapping,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5899,6 +5899,20 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testFrontendSupportedFeatures() throws {
+    var driver = try Driver(args: ["swift", "-print-supported-features"])
+
+    guard driver.isFrontendArgSupported(.printSupportedFeatures) else {
+      throw XCTSkip("Skipping: compiler does not support '-print-supported-features'")
+    }
+
+    let plannedJobs = try driver.planBuild()
+    XCTAssertEqual(plannedJobs.count, 1)
+    let job = plannedJobs[0]
+    XCTAssertEqual(job.kind, .printSupportedFeatures)
+    XCTAssertJobInvocationMatches(job, .flag("-print-supported-features"))
+  }
+
   func testPrintOutputFileMap() throws {
     try withTemporaryDirectory { path in
       // Replace the error stream with one we capture here.


### PR DESCRIPTION
This makes it possible to use `-print-supported-features` directly
on `swift{c}` and without any extra flags just like `-print-target-info`.