### PR TITLE
[Incremental Builds]optimize performance for ModuleDependencyGraph by reducing the number of external dependencies from N*M to N+M

### DIFF
--- a/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/IncrementalCompilation/ModuleDependencyGraph.swift
@@ -1350,6 +1350,30 @@ extension ModuleDependencyGraph {
             }
           }
         }
+        if graph.nodeFinder.enableExperimatalExternalDependenciesHashOptimization {
+          var hasWrittenAllExternalDependentNodes = false
+          for key in graph.nodeFinder.externalDependencies {
+            serializer.stream.writeRecord(serializer.abbreviations[.dependsOnNode]!) {
+              $0.append(RecordID.dependsOnNode)
+              write(key: key, to: &$0)
+            }
+            
+            for use in graph.nodeFinder.externalDependentNodes {
+              guard let useID = serializer.nodeIDs[use] else {
+                fatalError("Node ID was not registered! \(use)")
+              }
+
+              serializer.stream.writeRecord(serializer.abbreviations[.useIDNode]!) {
+                $0.append(RecordID.useIDNode)
+                $0.append(UInt32(useID))
+              }
+              if hasWrittenAllExternalDependentNodes {
+                break
+              }
+            }
+            hasWrittenAllExternalDependentNodes = true
+          }
+        }
         for fingerprintedExternalDependency in graph.fingerprintedExternalDependencies {
           serializer.stream.writeRecord(serializer.abbreviations[.externalDepNode]!) {
             $0.append(RecordID.externalDepNode)


### PR DESCRIPTION
# Swift driver version
swift-driver version: 1.115 Apple Swift version 6.0.2 (swiftlang-6.0.2.1.2 clang-1600.0.26.4)
Target: arm64-apple-macosx14.0

# Backgound
A swift module has 2500 swift files and 10000 external dependencies. These external dependencies include over 100 swift modules, along with a majority of header files. Thus, the `graph.nodeFinder.usesByDef` has 2500 * 10000 nodes of external dependencies，slowing down the Incremental build speed. 

# Improvement
  | swift-driver total duration | planBuild | run(jobs:) | .priors file size | nodes number of external dependencies 
-- | -- | -- | -- | -- | --
Before optimization | 33s | 24.61s | 6.11s | 162M | N * M
After optimization | 12s | 8.50s | 2.10s | 53M | N + M
Optimization improvement | 63.6% | 65.5% | 65.6% | 67.3% | - |
