### PR TITLE
[Tests] Remove a check for compiler side diagnostics

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -873,7 +873,6 @@ final class CachingBuildTests: XCTestCase {
 
       XCTAssertEqual(testDiagnostics.count, 1)
       XCTAssertEqual(testDiagnostics[0].severity, .error)
-      XCTAssertEqual(testDiagnostics[0].message, "CAS error encountered: conflicting CAS options used in scanning service")
     }
   }
 


### PR DESCRIPTION
Remove a check for the exact diagnostics message from the compiler side as it is out of scope for the test and it prohibits improvements to the diagnostics message from the compiler.