### PR TITLE
[6.2][Test-Only] Remove a check for compiler side diagnostics

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -873,7 +873,6 @@ final class CachingBuildTests: XCTestCase {
 
       XCTAssertEqual(testDiagnostics.count, 1)
       XCTAssertEqual(testDiagnostics[0].severity, .error)
-      XCTAssertEqual(testDiagnostics[0].message, "CAS error encountered: conflicting CAS options used in scanning service")
     }
   }
 


### PR DESCRIPTION
  - **Explanation**: Remove a check that on the diagnostic message that is on the swift compiler side, that should out of scope of the test.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: To enable future cherry-picks of the swift compiler change that update the message.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: N/A
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**:https://github.com/swiftlang/swift-driver/pull/1882
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**:Low. Test Only change. 
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: N/A
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @artemcm 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->