### PR TITLE
[6.2][SwiftCaching] Don't leak output path in the explicit module map JSON

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -296,9 +296,9 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     // SwiftModuleArtifactInfo
     guard moduleId == .swift(dependencyGraph.mainModuleName) else { return }
     let dependencyFileContent =
-      try serializeModuleDependencies(for: moduleId,
-                                      swiftDependencyArtifacts: swiftDependencyArtifacts,
-                                      clangDependencyArtifacts: clangDependencyArtifacts)
+      try serializeModuleDependencies(swiftDependencyArtifacts: swiftDependencyArtifacts,
+                                      clangDependencyArtifacts: clangDependencyArtifacts,
+                                      cachingEnabled: cas != nil)
     if let cas = self.cas {
       // When using a CAS, write JSON into CAS and pass the ID on command-line.
       let casID = try cas.store(data: dependencyFileContent)
@@ -534,9 +534,9 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
                             "-Xcc", "-fno-implicit-module-maps")
 
     let dependencyFileContent =
-      try serializeModuleDependencies(for: mainModuleId,
-                                      swiftDependencyArtifacts: swiftDependencyArtifacts,
-                                      clangDependencyArtifacts: clangDependencyArtifacts)
+      try serializeModuleDependencies(swiftDependencyArtifacts: swiftDependencyArtifacts,
+                                      clangDependencyArtifacts: clangDependencyArtifacts,
+                                      cachingEnabled: false)
 
     let dependencyFile =
       try VirtualPath.createUniqueTemporaryFileWithKnownContents(.init(validating: "\(mainModuleId.moduleName)-dependencies.json"),
@@ -548,15 +548,43 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
   }
 
   /// Serialize the output file artifacts for a given module in JSON format.
-  private func serializeModuleDependencies(for moduleId: ModuleDependencyId,
-                                           swiftDependencyArtifacts: Set<SwiftModuleArtifactInfo>,
-                                           clangDependencyArtifacts: Set<ClangModuleArtifactInfo>
+  private func serializeModuleDependencies(swiftDependencyArtifacts: Set<SwiftModuleArtifactInfo>,
+                                           clangDependencyArtifacts: Set<ClangModuleArtifactInfo>,
+                                           cachingEnabled: Bool
   ) throws -> Data {
+    // Helper function to abstract the path.
+    func abstractPath(_ module: String, suffix: String) throws -> TextualVirtualPath {
+      let path = try VirtualPath(path: module + suffix)
+      return TextualVirtualPath(path: path.intern())
+    }
     // The module dependency map in CAS needs to be stable.
-    // Sort the dependencies by name.
+    // For caching build, updated the dependency info to exclude paths that are compiler outputs from the mapping.
+    // Use abstract names and paths because caching build loads modules directly from CAS.
     let allDependencyArtifacts: [ModuleDependencyArtifactInfo] =
-      swiftDependencyArtifacts.sorted().map {ModuleDependencyArtifactInfo.swift($0)} +
-      clangDependencyArtifacts.sorted().map {ModuleDependencyArtifactInfo.clang($0)}
+      try swiftDependencyArtifacts.sorted().map { info in
+        if !cachingEnabled {
+          return ModuleDependencyArtifactInfo.swift(info)
+        }
+        let updatedInfo = try SwiftModuleArtifactInfo(name: info.moduleName,
+                                                      modulePath: abstractPath(info.moduleName, suffix: ".swiftmodule"),
+                                                      docPath: nil,
+                                                      sourceInfoPath: nil,
+                                                      headerDependencies: info.prebuiltHeaderDependencyPaths,
+                                                      isFramework: info.isFramework,
+                                                      moduleCacheKey: info.moduleCacheKey)
+        return ModuleDependencyArtifactInfo.swift(updatedInfo)
+      } +
+      clangDependencyArtifacts.sorted().map { info in
+        if !cachingEnabled {
+          return ModuleDependencyArtifactInfo.clang(info)
+        }
+        let updatedInfo = try ClangModuleArtifactInfo(name: info.moduleName,
+                                                      modulePath: abstractPath(info.moduleName, suffix: ".pcm"),
+                                                      moduleMapPath: info.clangModuleMapPath,
+                                                      moduleCacheKey: info.clangModuleCacheKey,
+                                                      isBridgingHeaderDependency: info.isBridgingHeaderDependency)
+        return ModuleDependencyArtifactInfo.clang(updatedInfo)
+      }
     let encoder = JSONEncoder()
     // Use sorted key to ensure the order of the keys is stable.
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]


### PR DESCRIPTION
  - **Explanation**:Using an abstract name for the module path for swift caching build because caching build loads modules directly from CAS and the path is insignificant. The abstract module path allows cache hits across different output locations.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**:Allow swift caching to have more cache hit opportunities
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**:rdar://149960868
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**:https://github.com/swiftlang/swift-driver/pull/1883
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**:Low. Swift caching only.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Covered by original unit tests. 
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @artemcm 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->