### PR TITLE
Add WASI as a supported target for ASan

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2751,7 +2751,7 @@ extension Driver {
     }
 
     // Check that we're one of the known supported targets for sanitizers.
-    if !(targetTriple.isWindows || targetTriple.isDarwin || targetTriple.os == .linux) {
+    if !(targetTriple.isWindows || targetTriple.isDarwin || targetTriple.os == .linux || targetTriple.os == .wasi) {
       diagnosticEngine.emit(
         .error_unsupported_opt_for_target(
           arg: "-sanitize=",

--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -165,8 +165,12 @@ extension WebAssemblyToolchain {
 
       // Delegate to Clang for sanitizers. It will figure out the correct linker
       // options.
-      guard sanitizers.isEmpty else {
-        throw Error.sanitizersUnsupportedForTarget(targetTriple.triple)
+      if linkerOutputType == .executable && !sanitizers.isEmpty {
+        let sanitizerNames = sanitizers
+          .map { $0.rawValue }
+          .sorted() // Sort so we get a stable, testable order
+          .joined(separator: ",")
+        commandLine.appendFlag("-fsanitize=\(sanitizerNames)")
       }
 
       if parsedOptions.hasArgument(.profileGenerate) {

--- a/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/WebAssemblyToolchain.swift
@@ -146,7 +146,12 @@ public final class WebAssemblyToolchain: Toolchain {
     targetTriple: Triple,
     isShared: Bool
   ) throws -> String {
-    throw Error.sanitizersUnsupportedForTarget(targetTriple.triple)
+    switch sanitizer {
+    case .address:
+      return "libclang_rt.\(sanitizer.libraryName)-\(targetTriple.archName).a"
+    default:
+      throw Error.sanitizersUnsupportedForTarget(targetTriple.triple)
+    }
   }
 
   public func platformSpecificInterpreterEnvironmentVariables(env: [String : String],


### PR DESCRIPTION
We are adding support for sanitizers on WASI targets. This commit adds driver support by unblocking hard-coded checks and forwarding sanitizer flags to clang linker driver.