### PR TITLE
Pass '-fpie' to the clang linker driver on Linux, instead of 'pie'

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -101,9 +101,9 @@ extension GenericUnixToolchain {
         commandLine.appendPath(toolsDir)
       }
 
-      // Executables on Linux get -pie
+      // Executables on Linux get -fpie
       if targetTriple.os == .linux && linkerOutputType == .executable {
-        commandLine.appendFlag("-pie")
+        commandLine.appendFlag("-fpie")
       }
 
       // On some platforms we want to enable --build-id

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2070,6 +2070,16 @@ final class SwiftDriverTests: XCTestCase {
     }
 
     do {
+      // Ensure executables get '-fpie'
+      var driver = try Driver(args: commonArgs + ["-emit-executable", "-L", "/tmp", "-target", "x86_64-unknown-linux"], env: env)
+      let plannedJobs = try driver.planBuild()
+      XCTAssertEqual(plannedJobs.count, 4)
+      let linkJob = plannedJobs[3]
+      let cmd = linkJob.commandLine
+      XCTAssertTrue(cmd.contains(subsequence: [.flag("-fpie")]))
+    }
+
+    do {
       // Xlinker flags
       // Ensure that Xlinker flags are passed as such to the clang linker invocation.
       try withTemporaryDirectory { path in


### PR DESCRIPTION
Resolves rdar://143793051