### PR TITLE
Do not add redundant `-pie` when building static executables on Linux platforms

### DIFF
--- a/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/GenericUnixToolchain+LinkerSupport.swift
@@ -83,6 +83,12 @@ extension GenericUnixToolchain {
         }
       }
 
+      let staticStdlib = parsedOptions.hasFlag(positive: .staticStdlib,
+                                               negative: .noStaticStdlib,
+                                                   default: false)
+      let staticExecutable = parsedOptions.hasFlag(positive: .staticExecutable,
+                                                   negative: .noStaticExecutable,
+                                                  default: false)
       let clangTool: Tool = cxxCompatEnabled ? .clangxx : .clang
       var clangPath = try getToolPath(clangTool)
       if let toolsDirPath = parsedOptions.getLastArgument(.toolsDirectory) {
@@ -102,7 +108,7 @@ extension GenericUnixToolchain {
       }
 
       // Executables on Linux get -pie
-      if targetTriple.os == .linux && linkerOutputType == .executable {
+      if targetTriple.os == .linux && linkerOutputType == .executable && !staticExecutable {
         commandLine.appendFlag("-pie")
       }
 
@@ -129,12 +135,6 @@ extension GenericUnixToolchain {
         }
       }
 
-      let staticStdlib = parsedOptions.hasFlag(positive: .staticStdlib,
-                                               negative: .noStaticStdlib,
-                                                   default: false)
-      let staticExecutable = parsedOptions.hasFlag(positive: .staticExecutable,
-                                                   negative: .noStaticExecutable,
-                                                  default: false)
       let isEmbeddedEnabled = parsedOptions.isEmbeddedEnabled
 
       let toolchainStdlibRpath = parsedOptions


### PR DESCRIPTION
It otherwise results in a warning from the Clang linker driver.

Resolves rdar://143793051