### PR TITLE
Color output on screen256 color terminals

### DIFF
--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -93,7 +93,8 @@ struct SwiftHelp: ParsableCommand {
   }
 
   func printIntro() {
-    let is256Color = ProcessEnv.vars["TERM"] == "xterm-256color"
+    let is256Color = ProcessEnv.block["TERM"] == "xterm-256color" ||
+      ProcessEnv.block["TERM"] == "screen-256color"
     let orangeRed = is256Color ? "\u{001b}[1;38;5;196m" : ""
     let plain = is256Color ? "\u{001b}[0m" : ""
     let plainBold = is256Color ? "\u{001b}[1m" : ""


### PR DESCRIPTION
The Swift driver only emitted color on xterm-256color terminals. screen-256color terminals also have the ability to output colors so we can colorize the output there too.

Also fixing the build deprecation warning on `ProcessEnv.vars`.