### PR TITLE
[6.2] Allow linking `_Concurrency` for WASI with Embedded Swift

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6901,7 +6901,6 @@ final class SwiftDriverTests: XCTestCase {
         let plannedJobs = try driver.planBuild()
         XCTAssertEqual(plannedJobs.count, 1)
         let linkJob = plannedJobs[0]
-        print(linkJob.commandLine)
         XCTAssertFalse(linkJob.commandLine.contains(.flag("-force_load")))
         XCTAssertFalse(linkJob.commandLine.contains(.flag("-rpath")))
         XCTAssertFalse(linkJob.commandLine.contains(.flag("-lswiftCore")))

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6890,16 +6890,25 @@ final class SwiftDriverTests: XCTestCase {
     do {
       for tripleEnv in ["wasi", "wasi-wasm", "wasip1", "wasip1-wasm", "wasip1-threads"] {
         var driver = try Driver(
-          args: ["swiftc", "-target", "wasm32-unknown-\(tripleEnv)", "test.o", "-enable-experimental-feature", "Embedded", "-wmo", "-o", "a.wasm"],
+          args: [
+            "swiftc", "-target", "wasm32-unknown-\(tripleEnv)",
+            "-resource-dir", "/usr/lib/swift",
+            "-enable-experimental-feature", "Embedded", "-wmo",
+            "test.o", "-o",  "a.wasm"
+          ],
           env: env
         )
         let plannedJobs = try driver.planBuild()
         XCTAssertEqual(plannedJobs.count, 1)
         let linkJob = plannedJobs[0]
+        print(linkJob.commandLine)
         XCTAssertFalse(linkJob.commandLine.contains(.flag("-force_load")))
         XCTAssertFalse(linkJob.commandLine.contains(.flag("-rpath")))
         XCTAssertFalse(linkJob.commandLine.contains(.flag("-lswiftCore")))
         XCTAssertFalse(linkJob.commandLine.joinedUnresolvedArguments.contains("swiftrt.o"))
+        XCTAssertTrue(linkJob.commandLine.contains(
+          .joinedOptionAndPath("-L", try .init(path: "/usr/lib/swift/embedded/wasm32-unknown-\(tripleEnv)"))
+        ))
       }
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-driver/pull/1863.

**Explanation**: Currently, when building packages for WASI with Embedded Swift, libraries such as `libswift_Concurrency.a` and `libswift_ConcurrencyDefaultExecutor.a` are not discoverable and require passing `-Xlinker <swift-sdk-path>/usr/lib/swift/embedded/wasm32-unknown-wasip1` option manually. This path can be inferred by the driver, which simplifies build invocations for users significantly, while the rest of linkage options (`-lswift_Concurrency` etc) can be specified in toolset files.
**Scope**: Limited to Embedded Swift for Wasm.
**Risk**: Low due to limited scope.
**Testing**: Added new automated test cases.
**Issue**: rdar://148820885
**Reviewer**: @kateinoigakukun