### PR TITLE
[6.2] PrebuiltModuleGen: print entire compiler invocation for failed module generation job

### DIFF
--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -247,10 +247,10 @@ fileprivate class ModuleCompileDelegate: JobExecutionDelegate {
       }
 #if os(Windows)
     case .abnormal(let exception):
-      diagnosticsEngine.emit(.remark("\(job.moduleName) exception: \(exception)"))
+      diagnosticsEngine.emit(.error(try! result.utf8stderrOutput()))
 #else
     case .signalled:
-      diagnosticsEngine.emit(.remark("\(job.moduleName) interrupted"))
+      diagnosticsEngine.emit(.error(try! result.utf8stderrOutput()))
 #endif
     }
     do {


### PR DESCRIPTION
Cherry-picking: https://github.com/swiftlang/swift-driver/pull/1910

Explanation: Without this change, the build log of a failing prebuilt module generation job doesn't contain the stack trace if the underlying compiler invocation crashed, adding extra process for triaging the failure. This change teaches the tool to emit crash trace to the build log.

Scope: Swift prebuilt module generation.

Risk: None. This is to add more diagnostics to an already-failing task

Testing: Tested locally that build logs are now with failing compiler invocations

Issue: rdar://152342109

Reviewer: @artemredkin 

