### PR TITLE
FreeBSD: Fix rpath to swift runtimes

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -105,6 +105,11 @@ def get_swiftpm_options(args):
       swiftpm_args += [
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/android',
       ]
+    elif '-freebsd' in args.build_target:
+      # Library rpath for swift, dispatch, Foundation, etc. when installing
+      swiftpm_args += [
+        '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/freebsd',
+      ]
     else:
       # Library rpath for swift, dispatch, Foundation, etc. when installing
       swiftpm_args += [


### PR DESCRIPTION
The build_os in build-script includes the platform version number from the target triple. The runtimes are installed to a location that does not include the version number, resulting in the swift-driver failing to launch due to not finding libswiftCore. Fixing the rpath to avoid requiring folks to manually specify the correct location through environment variables.