### PR TITLE
[Options] Switch -Isystem to -I if the front end doesn't support -Isystem

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -190,7 +190,17 @@ extension Driver {
     }
 
     // TODO: Can we drop all search paths for compile jobs for explicit module build?
-    try addAllArgumentsWithPath(.I, .Isystem, to: &commandLine, remap: jobNeedPathRemap)
+    if isFrontendArgSupported(.Isystem) {
+      try addAllArgumentsWithPath(.I, .Isystem, to: &commandLine, remap: jobNeedPathRemap)
+    } else {
+      for matching in parsedOptions.arguments(for: .I, .Isystem) {
+        var parsedOption = matching
+        if parsedOption.option == .Isystem {
+          parsedOption = ParsedOption(option: .I, argument: parsedOption.argument, index: parsedOption.index)
+        }
+        try addPathOption(parsedOption, to: &commandLine, remap: jobNeedPathRemap)
+      }
+    }
     try addAllArgumentsWithPath(.F, .Fsystem, to: &commandLine, remap: jobNeedPathRemap)
     try addAllArgumentsWithPath(.vfsoverlay, to: &commandLine, remap: jobNeedPathRemap)
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -229,10 +229,11 @@ final class SwiftDriverTests: XCTestCase {
     // The relative ordering of -F and -Fsystem options should be preserved.
     // The relative ordering of -I and -Isystem, and -F and -Fsystem options should be preserved,
     // but all -I options should come before all -F options.
+    let IsystemFlag = driver.isFrontendArgSupported(.Isystem) ? "-Isystem" : "-I"
     try XCTAssertJobInvocationMatches(jobs[0],
                                      .flag("-I"),
                                      .path(.absolute(.init(validating: "/path/to/modules"))),
-                                     .flag("-Isystem"),
+                                     .flag(IsystemFlag),
                                      .path(.absolute(.init(validating: "/path/to/systemmodules"))),
                                      .flag("-I"),
                                      .path(.absolute(.init(validating: "/path/to/more/modules"))),


### PR DESCRIPTION
If the front end doesn't support -Isystem, pass it as -I instead.

rdar://152602098