### PR TITLE
build: update the pinned version of swift-argument-parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(NOT ArgumentParser_FOUND)
   message("-- Vending swift-argument-parser")
   FetchContent_Declare(ArgumentParser
     GIT_REPOSITORY https://github.com/apple/swift-argument-parser
-    GIT_TAG 1.2.3)
+    GIT_TAG 1.5.1)
   list(APPEND VendoredDependencies ArgumentParser)
 endif()
 


### PR DESCRIPTION
Update the pinned version of swift-argument-parser in the CMakeLists.txt. This fully migrates the package over to the new swift-argument-parser release.