### PR TITLE
Add swift crash producer support

### DIFF
--- a/Sources/SwiftDriver/Execution/DriverExecutor.swift
+++ b/Sources/SwiftDriver/Execution/DriverExecutor.swift
@@ -206,6 +206,9 @@ public protocol JobExecutionDelegate {
 
   /// Called when a job is skipped.
   func jobSkipped(job: Job)
+
+  /// Create a new job that constructs a reproducer for the providing job.
+  func getReproducerJob(job: Job, output: VirtualPath) -> Job?
 }
 
 @_spi(Testing) public extension ProcessEnvironmentBlock {

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -1071,6 +1071,23 @@ extension Driver {
   }
 }
 
+// Generate reproducer.
+extension Driver {
+  var supportsReproducer: Bool {
+    isFrontendArgSupported(.genReproducer) && enableCaching
+  }
+
+  static func generateReproducer(_ job: Job, _ output: VirtualPath) -> Job {
+    var reproJob = job
+    reproJob.commandLine.appendFlag(.genReproducer)
+    reproJob.commandLine.appendFlag(.genReproducerDir)
+    reproJob.commandLine.appendPath(output)
+    reproJob.outputs.removeAll()
+    reproJob.outputCacheKeys.removeAll()
+    return reproJob
+  }
+}
+
 extension ParsedOptions {
   /// Checks whether experimental embedded mode is enabled.
   var isEmbeddedEnabled: Bool {

--- a/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrebuiltModulesJob.swift
@@ -270,6 +270,9 @@ fileprivate class ModuleCompileDelegate: JobExecutionDelegate {
   static func canHandle(job: Job) -> Bool {
     return job.kind == .compile
   }
+  func getReproducerJob(job: Job, output: VirtualPath) -> Job? {
+    nil
+  }
 }
 
 fileprivate class ABICheckingDelegate: JobExecutionDelegate {
@@ -277,6 +280,9 @@ fileprivate class ABICheckingDelegate: JobExecutionDelegate {
   let logPath: AbsolutePath?
 
   func jobSkipped(job: Job) {}
+  func getReproducerJob(job: Job, output: VirtualPath) -> Job? {
+    nil
+  }
 
   public init(_ verbose: Bool, _ logPath: AbsolutePath?) {
     self.verbose = verbose
@@ -338,6 +344,9 @@ public class PrebuiltModuleGenerationDelegate: JobExecutionDelegate {
 
   public func jobSkipped(job: Job) {
     selectDelegate(job: job).jobSkipped(job: job)
+  }
+  public func getReproducerJob(job: Job, output: VirtualPath) -> Job? {
+    selectDelegate(job: job).getReproducerJob(job: job, output: output)
   }
   public var shouldRunDanglingJobs: Bool {
     return compileDelegate.shouldRunDanglingJobs

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -586,6 +586,8 @@ extension Option {
   public static let F: Option = Option("-F", .joinedOrSeparate, attributes: [.frontend, .synthesizeInterface, .argumentIsPath], helpText: "Add directory to framework search path")
   public static let gccToolchain: Option = Option("-gcc-toolchain", .separate, attributes: [.helpHidden, .argumentIsPath], metaVar: "<path>", helpText: "Specify a directory where the clang importer and clang linker can find headers and libraries")
   public static let gdwarfTypes: Option = Option("-gdwarf-types", .flag, attributes: [.frontend], helpText: "Emit full DWARF type info.", group: .g)
+  public static let genReproducerDir: Option = Option("-gen-reproducer-dir", .separate, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Path to directory where reproducers write to.")
+  public static let genReproducer: Option = Option("-gen-reproducer", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Generate a reproducer for current compilation.")
   public static let generateEmptyBaseline: Option = Option("-generate-empty-baseline", .flag, attributes: [.noDriver], helpText: "Generate an empty baseline")
   public static let generateEmptyBaseline_: Option = Option("--generate-empty-baseline", .flag, alias: Option.generateEmptyBaseline, attributes: [.noDriver], helpText: "Generate an empty baseline")
   public static let generateMigrationScript: Option = Option("-generate-migration-script", .flag, attributes: [.noDriver], helpText: "Compare SDK content in JSON file and generate migration script")
@@ -1553,6 +1555,8 @@ extension Option {
       Option.F,
       Option.gccToolchain,
       Option.gdwarfTypes,
+      Option.genReproducerDir,
+      Option.genReproducer,
       Option.generateEmptyBaseline,
       Option.generateEmptyBaseline_,
       Option.generateMigrationScript,

--- a/Tests/SwiftDriverTests/JobExecutorTests.swift
+++ b/Tests/SwiftDriverTests/JobExecutorTests.swift
@@ -58,6 +58,10 @@ class JobCollectingDelegate: JobExecutionDelegate {
   }
 
   func jobSkipped(job: Job) {}
+
+  func getReproducerJob(job: Job, output: VirtualPath) -> Job? {
+    nil
+  }
 }
 
 extension DarwinToolchain {


### PR DESCRIPTION
When swift compiler crashed with swift caching enabled, create a crash reproducer automatically.