### PR TITLE
[6.2][ABIChecking] swift-api-digester doesn't support -isystem

### DIFF
--- a/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
+++ b/Sources/SwiftDriver/Jobs/APIDigesterJobs.swift
@@ -195,7 +195,7 @@ extension Driver {
 
     try commandLine.appendAll(.I, from: &parsedOptions)
     for systemImport in parsedOptions.arguments(for: .Isystem) {
-      commandLine.appendFlag("-isystem")
+      commandLine.appendFlag(.I)
       commandLine.appendFlag(systemImport.argument.asSingle)
     }
     try commandLine.appendAll(.F, from: &parsedOptions)


### PR DESCRIPTION
swift-api-digester doesn't support the -isystem clang flag like it does the -iframework one. Use -I for now.

rdar://153664788