### PR TITLE
[Explicit Module Builds] Ensure that plugin paths are specified to the dependency scanning invocation

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -81,7 +81,7 @@ extension Driver {
       break
     }
 
-    let isPlanJobForExplicitModule = parsedOptions.contains(.driverExplicitModuleBuild)
+    let isPlanJobForExplicitModule = parsedOptions.contains(.driverExplicitModuleBuild) && explicitModulePlanner != nil
     let jobNeedPathRemap: Bool
     // If in ExplicitModuleBuild mode and the dependency graph has been computed, add module
     // dependencies.


### PR DESCRIPTION
b0a01d3a283f6aa63ac64d0aa5af3d0cc8b64fc7 accidentally broke this by restricting these flags to never get passed when EBM is enabled, as opposed to ensuring they get passed on non-EBM and dependency scanning tasks.

Resolves rdar://154326377