### PR TITLE
[Macro] Do not drop `in-process-plugin-server-path` option

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -934,6 +934,9 @@ final class CachingBuildTests: XCTestCase {
         })
         /// command-line that compiles swift should contains -cache-replay-prefix-map
         XCTAssertTrue(command.contains { $0 == "-cache-replay-prefix-map" })
+        if job.kind == .compile {
+          XCTAssertTrue(command.contains { $0 == "-in-process-plugin-server-path" })
+        }
         XCTAssertFalse(command.contains { $0 == "-plugin-path" || $0 == "-external-plugin-path" ||
                                           $0 == "-load-plugin-library" || $0 == "-load-plugin-executable" })
       }

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -2042,6 +2042,14 @@ final class ExplicitModuleBuildTests: XCTestCase {
       var scannerCommand = try driver.dependencyScannerInvocationCommand().1.map { try resolver.resolve($0) }
       XCTAssertTrue(scannerCommand.contains("-plugin-path"))
       XCTAssertTrue(scannerCommand.contains("-external-plugin-path"))
+      let jobs = try driver.planBuild()
+      for job in jobs {
+        if job.kind != .compile {
+          continue
+        }
+        let command = try job.commandLine.map { try resolver.resolve($0) }
+        XCTAssertTrue(command.contains { $0 == "-in-process-plugin-server-path" })
+      }
     }
   }
 


### PR DESCRIPTION
Fix a regression that `in-process-plugin-server-path` is accidentally dropped in explicit module build.

rdar://154780122