### PR TITLE
[6.2 🍒][Explicit Module Builds] Add support for libSwiftScan API to query source import details

### DIFF
--- a/Sources/CSwiftScan/include/swiftscan_header.h
+++ b/Sources/CSwiftScan/include/swiftscan_header.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 
 #define SWIFTSCAN_VERSION_MAJOR 2
-#define SWIFTSCAN_VERSION_MINOR 1
+#define SWIFTSCAN_VERSION_MINOR 2
 
 //=== Public Scanner Data Types -------------------------------------------===//
 
@@ -44,6 +44,7 @@ typedef struct swiftscan_dependency_info_s *swiftscan_dependency_info_t;
 typedef struct swiftscan_link_library_info_s *swiftscan_link_library_info_t;
 typedef struct swiftscan_dependency_graph_s *swiftscan_dependency_graph_t;
 typedef struct swiftscan_import_set_s *swiftscan_import_set_t;
+typedef struct swiftscan_import_info_s *swiftscan_import_info_t;
 typedef struct swiftscan_diagnostic_info_s *swiftscan_diagnostic_info_t;
 typedef struct swiftscan_source_location_s *swiftscan_source_location_t;
 
@@ -53,6 +54,13 @@ typedef enum {
   SWIFTSCAN_DIAGNOSTIC_SEVERITY_NOTE = 2,
   SWIFTSCAN_DIAGNOSTIC_SEVERITY_REMARK = 3
 } swiftscan_diagnostic_severity_t;
+typedef enum {
+  SWIFTSCAN_ACCESS_LEVEL_PRIVATE = 0,
+  SWIFTSCAN_ACCESS_LEVEL_FILEPRIVATE = 1,
+  SWIFTSCAN_ACCESS_LEVEL_INTERNAL = 2,
+  SWIFTSCAN_ACCESS_LEVEL_PACKAGE = 3,
+  SWIFTSCAN_ACCESS_LEVEL_PUBLIC = 4
+} swiftscan_access_level_t;
 typedef struct {
   swiftscan_diagnostic_info_t *diagnostics;
   size_t count;
@@ -65,6 +73,14 @@ typedef struct {
   swiftscan_link_library_info_t *link_libraries;
   size_t count;
 } swiftscan_link_library_set_t;
+typedef struct {
+  swiftscan_import_info_t *imports;
+  size_t count;
+} swiftscan_import_info_set_t;
+typedef struct {
+  swiftscan_source_location_t *source_locations;
+  size_t count;
+} swiftscan_source_location_set_t;
 
 //=== Scanner Invocation Specification ------------------------------------===//
 
@@ -105,6 +121,8 @@ typedef struct {
   (*swiftscan_module_info_get_direct_dependencies)(swiftscan_dependency_info_t);
   swiftscan_link_library_set_t *
   (*swiftscan_module_info_get_link_libraries)(swiftscan_dependency_graph_t);
+  swiftscan_import_info_set_t *
+  (*swiftscan_module_info_get_imports)(swiftscan_dependency_graph_t);
   swiftscan_module_details_t
   (*swiftscan_module_info_get_details)(swiftscan_dependency_info_t);
 
@@ -115,6 +133,14 @@ typedef struct {
   (*swiftscan_link_library_info_get_is_framework)(swiftscan_link_library_info_t);
   bool
   (*swiftscan_link_library_info_get_should_force_load)(swiftscan_link_library_info_t);
+
+  //=== Import Details Functions -------------------------------------------===//
+  swiftscan_source_location_set_t *
+  (*swiftscan_import_info_get_source_locations)(swiftscan_import_info_t info);
+  swiftscan_string_ref_t
+  (*swiftscan_import_info_get_identifier)(swiftscan_import_info_t info);
+  swiftscan_access_level_t
+  (*swiftscan_import_info_get_access_level)(swiftscan_import_info_t info);
 
   //=== Dependency Module Info Details Functions ----------------------------===//
   swiftscan_dependency_info_kind_t

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyGraph.swift
@@ -101,6 +101,29 @@ public struct LinkLibraryInfo: Codable, Hashable {
   public var shouldForceLoad: Bool
 }
 
+/// Source 'import'
+public struct ImportInfo : Codable, Hashable {
+  public enum ImportAccessLevel : Codable, Hashable {
+    case Private
+    case FilePrivate
+    case Internal
+    case Package
+    case Public
+  }
+
+  public var importIdentifier: String
+  public var accessLevel: ImportAccessLevel
+  public var sourceLocations: [ScannerDiagnosticSourceLocation]
+
+  @_spi(Testing) public init(importIdentifier: String,
+                             accessLevel: ImportAccessLevel,
+                             sourceLocations: [ScannerDiagnosticSourceLocation]) {
+    self.importIdentifier = importIdentifier
+    self.accessLevel = accessLevel
+    self.sourceLocations = sourceLocations
+  }
+}
+
 /// Details specific to Swift modules.
 public struct SwiftModuleDetails: Codable, Hashable {
   /// The module interface from which this module was built, if any.
@@ -212,6 +235,9 @@ public struct ModuleInfo: Codable, Hashable {
   /// The set of libraries that need to be linked
   public var linkLibraries: [LinkLibraryInfo]?
 
+  /// The set of import details of this module
+  public var importInfos: [ImportInfo]?
+
   /// Specific details of a particular kind of module.
   public var details: Details
 
@@ -236,11 +262,13 @@ public struct ModuleInfo: Codable, Hashable {
               sourceFiles: [String]?,
               directDependencies: [ModuleDependencyId]?,
               linkLibraries: [LinkLibraryInfo]?,
+              importInfos: [ImportInfo]?,
               details: Details) {
     self.modulePath = modulePath
     self.sourceFiles = sourceFiles
     self.directDependencies = directDependencies
     self.linkLibraries = linkLibraries
+    self.importInfos = importInfos
     self.details = details
   }
 }

--- a/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/InterModuleDependencies/InterModuleDependencyOracle.swift
@@ -147,6 +147,13 @@ public class InterModuleDependencyOracle {
     return swiftScan.supportsLinkLibraries
   }
 
+  @_spi(Testing) public func supportsImportInfos() throws -> Bool {
+    guard let swiftScan = swiftScanLibInstance else {
+      fatalError("Attempting to query supported scanner API with no scanner instance.")
+    }
+    return swiftScan.supportsImportInfos
+  }
+
   @_spi(Testing) public func supportsSeparateImportOnlyDependencise() throws -> Bool {
     guard let swiftScan = swiftScanLibInstance else {
       fatalError("Attempting to query supported scanner API with no scanner instance.")

--- a/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
+++ b/Sources/SwiftDriver/SwiftScan/SwiftScan.swift
@@ -72,13 +72,21 @@ public enum DependencyScanningError: LocalizedError, DiagnosticData, Equatable {
   }
 }
 
-public struct ScannerDiagnosticSourceLocation : DiagnosticLocation {
+public struct ScannerDiagnosticSourceLocation : DiagnosticLocation, Codable, Hashable {
   public var description: String {
     return "\(bufferIdentifier):\(lineNumber):\(columnNumber)"
   }
   public let bufferIdentifier: String
   public let lineNumber: Int
   public let columnNumber: Int
+
+  @_spi(Testing) public init(bufferIdentifier: String,
+                             lineNumber: Int,
+                             columnNumber: Int) {
+    self.bufferIdentifier = bufferIdentifier
+    self.lineNumber = lineNumber
+    self.columnNumber = columnNumber
+  }
 }
 
 public struct ScannerDiagnosticPayload {
@@ -316,6 +324,13 @@ private extension String {
            api.swiftscan_link_library_info_get_link_name != nil &&
            api.swiftscan_link_library_info_get_is_framework != nil &&
            api.swiftscan_link_library_info_get_should_force_load != nil
+  }
+
+  @_spi(Testing) public var supportsImportInfos : Bool {
+    return api.swiftscan_module_info_get_imports != nil &&
+           api.swiftscan_import_info_get_source_locations != nil &&
+           api.swiftscan_import_info_get_identifier != nil &&
+           api.swiftscan_import_info_get_access_level != nil
   }
 
   internal func mapToDriverDiagnosticPayload(_ diagnosticSetRef: UnsafeMutablePointer<swiftscan_diagnostic_set_t>) throws -> [ScannerDiagnosticPayload] {
@@ -572,6 +587,11 @@ private extension swiftscan_functions_t {
     self.swiftscan_link_library_info_get_link_name = loadOptional("swiftscan_link_library_info_get_link_name")
     self.swiftscan_link_library_info_get_is_framework = loadOptional("swiftscan_link_library_info_get_is_framework")
     self.swiftscan_link_library_info_get_should_force_load = loadOptional("swiftscan_link_library_info_get_should_force_load")
+
+    self.swiftscan_module_info_get_imports = loadOptional("swiftscan_module_info_get_imports")
+    self.swiftscan_import_info_get_source_locations = loadOptional("swiftscan_import_info_get_source_locations")
+    self.swiftscan_import_info_get_identifier = loadOptional("swiftscan_import_info_get_identifier")
+    self.swiftscan_import_info_get_access_level = loadOptional("swiftscan_import_info_get_access_level")
 
     // Swift Overlay Dependencies
     self.swiftscan_swift_textual_detail_get_swift_overlay_dependencies =

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -533,8 +533,8 @@ final class ExplicitModuleBuildTests: XCTestCase {
                   "-I", cHeadersPath.nativePathString(escaped: true),
                   "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                   "-explicit-module-build",
-                  "-disable-implicit-concurrency-module-import",
-                  "-disable-implicit-string-processing-module-import",
+                  "-Xfrontend", "-disable-implicit-concurrency-module-import",
+                  "-Xfrontend", "-disable-implicit-string-processing-module-import",
                   main.nativePathString(escaped: true)] + sdkArgumentsForTesting
       var driver = try Driver(args: args)
       let _ = try driver.planBuild()
@@ -551,20 +551,20 @@ final class ExplicitModuleBuildTests: XCTestCase {
                                                           accessLevel: ImportInfo.ImportAccessLevel.Public,
                                                           sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
                                                                                                             lineNumber: 1,
-                                                                                                            columnNumber: 8),
+                                                                                                            columnNumber: 15),
                                                                             ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
                                                                                                             lineNumber: 4,
-                                                                                                            columnNumber: 8)])))
+                                                                                                            columnNumber: 17)])))
       XCTAssertTrue(mainModuleImports.contains(ImportInfo(importIdentifier: "E",
                                                           accessLevel: ImportInfo.ImportAccessLevel.Internal,
                                                           sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
                                                                                                             lineNumber: 2,
-                                                                                                            columnNumber: 8)])))
+                                                                                                            columnNumber: 17)])))
       XCTAssertTrue(mainModuleImports.contains(ImportInfo(importIdentifier: "G",
                                                           accessLevel: ImportInfo.ImportAccessLevel.Private,
                                                           sourceLocations: [ScannerDiagnosticSourceLocation(bufferIdentifier: main.nativePathString(escaped: true),
                                                                                                             lineNumber: 3,
-                                                                                                            columnNumber: 8)])))
+                                                                                                            columnNumber: 16)])))
     }
   }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-driver/pull/1928
------------------------------------------------------

- **Explanation**: Adding support and API for functionality added in: https://github.com/swiftlang/swift/pull/82169: access control field for each imported module identified.

- **Scope**: Builds which enable Explicitly built modules.

- **Risk**: Low. These changes are additive to the explicit dependency code paths and are not currently relied upon by build system clients.

- **Reviewed By**: @xymus

- **Problem**: rdar://148055487

- **Original PR**: https://github.com/swiftlang/swift-driver/pull/1928