### PR TITLE
SwiftDriverExecution: add explicit dependency on libllbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT LLBuild_FOUND)
     find_package(LLBuild REQUIRED)
   else()
     message("-- Vending swift-llbuild")
-    set(LLBUILD_SUPPORT_BINDINGS Swift)
+    set(LLBUILD_SUPPORT_BINDINGS Swift CACHE STRING "")
     FetchContent_Declare(LLBuild
       GIT_REPOSITORY https://github.com/apple/swift-llbuild
       GIT_TAG main)

--- a/Sources/SwiftDriverExecution/CMakeLists.txt
+++ b/Sources/SwiftDriverExecution/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(SwiftDriverExecution PUBLIC
   SwiftOptions
   SwiftDriver)
 target_link_libraries(SwiftDriverExecution PRIVATE
+  libllbuild
   llbuildSwift)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS SwiftDriverExecution)

--- a/Sources/SwiftDriverExecution/llbuild.swift
+++ b/Sources/SwiftDriverExecution/llbuild.swift
@@ -22,10 +22,8 @@ import protocol TSCBasic.FileSystem
 // We either import the llbuildSwift shared library or the llbuild framework.
 #if canImport(llbuildSwift)
 @_implementationOnly import llbuildSwift
-@_implementationOnly import llbuild
-#else
-@_implementationOnly import llbuild
 #endif
+@_implementationOnly import llbuild
 
 /// An llbuild value.
 protocol LLBuildValue: Codable {


### PR DESCRIPTION
The module directly imports libllbuild, and while the dependency _should_ be available due to the dependency on `llbuildSwift`, this ensures that we do not rely on ordering but rather the explicit dependency is codified into the build graph.