### PR TITLE
[ToolingInterface] Fix `V2` API should forward `forceNoOutputs` argument

### DIFF
--- a/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
+++ b/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
@@ -40,7 +40,8 @@ public func getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: UnsafeP
   return getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: driverPath, argListCount: argListCount,
                                                           argList: argList, action: action,
                                                           diagnosticCallback: diagnosticCallback,
-                                                          compilerIntegratedTooling: true)
+                                                          compilerIntegratedTooling: true,
+                                                          forceNoOutputs: forceNoOutputs)
 }
 
 @_cdecl("swift_getSingleFrontendInvocationFromDriverArgumentsV3")


### PR DESCRIPTION
While working on `swift-ide-test` integration I noticed that the `swift_getSingleFrontendInvocationFromDriverArgumentsV2` API doesn't forward `forceNoOutputs` argument.