### PR TITLE
[ToolingInterface] Fix `getSingleFrontendInvocationFromDriverArgumentsV3`

### DIFF
--- a/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
+++ b/Sources/SwiftDriver/ToolingInterface/ToolingUtil.swift
@@ -56,7 +56,7 @@ public func getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: UnsafeP
 
   // Bridge the argv equivalent
   let argListBufferPtr = UnsafeBufferPointer<UnsafePointer<CChar>?>(start: argList, count: Int(argListCount))
-  let bridgedArgList = [bridgedDriverPath] + argListBufferPtr.map { String(cString: $0!) }
+  let bridgedArgList = argListBufferPtr.map { String(cString: $0!) }
 
   // Bridge the action callback
   let bridgedAction: ([String]) -> Bool = { args in


### PR DESCRIPTION
... to avoid adding driver path to arguments

The path to the driver is passed down already and it would be added to the arguments by `getSingleFrontendInvocationFromDriverArgumentsV5`.