### PR TITLE
CrashReproducer generation improvements

### DIFF
--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -1082,6 +1082,12 @@ extension Driver {
     reproJob.commandLine.appendFlag(.genReproducer)
     reproJob.commandLine.appendFlag(.genReproducerDir)
     reproJob.commandLine.appendPath(output)
+    reproJob.commandLine.removeAll {
+      guard case let .flag(opt) = $0 else {
+        return false
+      }
+      return opt == Option.frontendParseableOutput.spelling
+    }
     reproJob.outputs.removeAll()
     reproJob.outputCacheKeys.removeAll()
     return reproJob

--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -23,6 +23,7 @@ import class TSCBasic.DiagnosticsEngine
 import class TSCBasic.Process
 import protocol TSCBasic.DiagnosticData
 import protocol TSCBasic.FileSystem
+import struct TSCBasic.AbsolutePath
 import struct TSCBasic.Diagnostic
 import struct TSCBasic.ProcessResult
 import func TSCBasic.withTemporaryDirectory
@@ -678,7 +679,13 @@ class ExecuteJobRule: LLBuildRule {
   }
 
   private func handleSignalledJob(for job: Job) throws {
-    try withTemporaryDirectory(dir: fileSystem.tempDirectory, prefix: "swift-reproducer", removeTreeOnDeinit: false) { tempDir in
+    let reproDir: AbsolutePath
+    if let pathFromEnv = context.env["SWIFT_CRASH_DIAGNOSTICS_DIR"] {
+      reproDir = try AbsolutePath(validating: pathFromEnv)
+    } else {
+      reproDir = try fileSystem.tempDirectory
+    }
+    try withTemporaryDirectory(dir: reproDir, prefix: "swift-crash-reproducer", removeTreeOnDeinit: false) { tempDir in
       guard let reproJob = context.executorDelegate.getReproducerJob(job: job, output: VirtualPath.absolute(tempDir)) else {
         return
       }


### PR DESCRIPTION
Add some improvements to crash reproducer:
* Allow environmental variable `SWIFT_CRASH_DIAGNOSTICS_DIR` to specify where the reproducer is written to.
* Add a testcase for generation reproducer since we can direct reproducer into a directory that can be cleared after testcase
* Do use parseable output when producing reproducer (to avoid polluting the stdout where build system might except build commands)