### PR TITLE
Swift Driver: Unknown Subcommand Location

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -51,7 +51,7 @@ extension Driver.ErrorDiagnostics: CustomStringConvertible {
 /// The Swift driver.
 public struct Driver {
   public enum Error: Swift.Error, Equatable, DiagnosticData {
-    case unknownOrMissingSubcommand(String)
+    case unknownOrMissingSubcommand(String, String?)
     case invalidDriverName(String)
     case invalidInput(String)
     case noInputFiles
@@ -82,7 +82,10 @@ public struct Driver {
 
     public var description: String {
       switch self {
-      case .unknownOrMissingSubcommand(let subcommand):
+      case .unknownOrMissingSubcommand(let subcommand, let directory):
+        if let directory {
+          return "unknown or missing subcommand '\(subcommand)' in '\(directory)'"
+        }
         return "unknown or missing subcommand '\(subcommand)'"
       case .invalidDriverName(let driverName):
         return "invalid driver name: \(driverName)"

--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -108,7 +108,11 @@ do {
       let legacyDriverCommand = [path] + CommandLine.arguments[1...]
       try exec(path: path, args: legacyDriverCommand)
     } else {
-      throw Driver.Error.unknownOrMissingSubcommand(legacyExecutablePath.lastPathComponent)
+      throw Driver.Error.unknownOrMissingSubcommand(
+        legacyExecutablePath.lastPathComponent,
+        legacyExecutablePath
+          .deletingLastPathComponent()
+          .withUnsafeFileSystemRepresentation { String(cString: $0!) })
     }
   }
 
@@ -127,7 +131,7 @@ do {
 
     guard let subcommandPath = subcommandPath,
           localFileSystem.exists(subcommandPath) else {
-      throw Driver.Error.unknownOrMissingSubcommand(subcommand)
+      throw Driver.Error.unknownOrMissingSubcommand(subcommand, nil)
     }
 
     // Pass the full path to subcommand executable.


### PR DESCRIPTION
Include the path that the Swift driver is looking for a subcommand in the error message. This makes it easier to see where the driver is looking, which isn't always next to the driver.

This is only applied to the swift-legacy-driver and swiftc-legacy-driver symlinks.