### PR TITLE
[6.2 🍒][ArgsResolver] Create specified temporary directory, if necessary

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -45,6 +45,10 @@ public final class ArgsResolver {
 
     if let temporaryDirectory = temporaryDirectory {
       self.temporaryDirectory = temporaryDirectory
+      let temporaryDirExists = try fileSystem.exists(self.temporaryDirectory)
+      if !temporaryDirExists, let temporaryDirAbsPath = self.temporaryDirectory.absolutePath {
+        try fileSystem.createDirectory(temporaryDirAbsPath, recursive: true)
+      }
     } else {
       // FIXME: withTemporaryDirectory uses FileManager.default, need to create a FileSystem.temporaryDirectory api.
       let tmpDir: AbsolutePath = try withTemporaryDirectory(removeTreeOnDeinit: false) { path in


### PR DESCRIPTION
- **Explanation**: https://github.com/swiftlang/swift-driver/pull/1939 fixed a bug where multiple driver instances could race on writing out an identical response file for a module dependency. With this code change, the new API used for writing a file differs from the prior approach in that it expects the written file's parent directory to already exist, whereas the previous API used would create said directory if one does not exist. As a consequence, in scenarios where such a directory was provided but does not exist, builds fail because the resolver fails to write out temporary files (response files, primarily). This PR resolves this driver-side by having the argument resolver check its input temporary directory and attempt to create it if it does not exist on the filesystem yet. 

- **Scope**: Builds in Driver clients which specify a custom `ArgsResolver` with a custom temporary directory which does not possibly exist yet.

- **Risk**: Low. The change should only affect clients of the driver which specify a custom `ArgsResolver` with a temporary directory which does not exist. With this change, such clients will no longer have the driver build planning fail due to the resolver's inability to write out temporary files. 

- **Reviewed By**: TBD

- **Problem**: rdar://157302464

- **Original PR**: https://github.com/swiftlang/swift-driver/pull/1963