### PR TITLE
[Build] Fix linking of llbuild

### DIFF
--- a/Sources/SwiftDriverExecution/CMakeLists.txt
+++ b/Sources/SwiftDriverExecution/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(SwiftDriverExecution PUBLIC
   SwiftOptions
   SwiftDriver)
 target_link_libraries(SwiftDriverExecution PRIVATE
-  libllbuild
+  llbuild
   llbuildSwift)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS SwiftDriverExecution)


### PR DESCRIPTION
In the cmake build, the lilbrary to link was specified as `libllbuild`, which caused the build to pass `-llibllbuild` to the linker, instead of `-lllbuild`.