### PR TITLE
Revert "[Build] Fix linking of llbuild"

### DIFF
--- a/Sources/SwiftDriverExecution/CMakeLists.txt
+++ b/Sources/SwiftDriverExecution/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(SwiftDriverExecution PUBLIC
   SwiftOptions
   SwiftDriver)
 target_link_libraries(SwiftDriverExecution PRIVATE
-  llbuild
+  libllbuild
   llbuildSwift)
 
 set_property(GLOBAL APPEND PROPERTY SWIFTDRIVER_EXPORTS SwiftDriverExecution)


### PR DESCRIPTION
Reverts swiftlang/swift-driver#1965

This fixes the build on Windows