### PR TITLE
Closes #1969 - Update 6.2.1 branch dependant package versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -147,7 +147,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
-            .package(url: "https://github.com/swiftlang/swift-llbuild.git", branch: "release/6.2"),
+            .package(url: "https://github.com/swiftlang/swift-llbuild.git", branch: "release/6.2.1"),
         ]
         package.targets.first(where: { $0.name == "SwiftDriverExecution" })!.dependencies += [
             .product(name: "llbuildSwift", package: "swift-llbuild"),
@@ -166,7 +166,7 @@ if ProcessInfo.processInfo.environment["SWIFT_DRIVER_LLBUILD_FWK"] == nil {
 
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: "release/6.2"),
+    .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: "release/6.2.1"),
     // The 'swift-argument-parser' version declared here must match that
     // used by 'swift-package-manager' and 'sourcekit-lsp'. Please coordinate
     // dependency version changes here with those projects.


### PR DESCRIPTION
* Update swift-llbuild and swift-tools-support-core to track the release/6.2.1 branch.