### PR TITLE
FreeBSD: Allow enabling sanitizers on FreeBSD

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -2751,7 +2751,9 @@ extension Driver {
     }
 
     // Check that we're one of the known supported targets for sanitizers.
-    if !(targetTriple.isWindows || targetTriple.isDarwin || targetTriple.os == .linux || targetTriple.os == .wasi) {
+    if !(targetTriple.isWindows ||
+      targetTriple.isDarwin ||
+      [.freeBSD, .linux, .wasi].contains(targetTriple.os)) {
       diagnosticEngine.emit(
         .error_unsupported_opt_for_target(
           arg: "-sanitize=",


### PR DESCRIPTION
TSAN, ASAN, MemSAN, and UBSAN all work on FreeBSD. Fixing the driver to allow enabling sanitizers on FreeBSD.