### PR TITLE
makeOptions: Fix CMake build for stable/21.x rebranch

### DIFF
--- a/Sources/makeOptions/CMakeLists.txt
+++ b/Sources/makeOptions/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(makeOptions
 set_target_properties(makeOptions PROPERTIES
   CXX_STANDARD 17)
 target_compile_definitions(makeOptions PRIVATE
-  LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+  LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1
+  LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR})
 target_include_directories(makeOptions PRIVATE
   ${SWIFT_INCLUDE_DIRS}
   ${LLVM_BUILD_BINARY_DIR}/include


### PR DESCRIPTION
Adjust the code to work with both stable/20240723 and stable/21.x after https://github.com/llvm/llvm-project/pull/119198. This saves us from having to cut and qualify a rebranch branch for swift-driver.