### PR TITLE
Always diagnose failures in job execution

### DIFF
--- a/Sources/SwiftDriverExecution/MultiJobExecutor.swift
+++ b/Sources/SwiftDriverExecution/MultiJobExecutor.swift
@@ -655,9 +655,8 @@ class ExecuteJobRule: LLBuildRule {
       context.cancelBuildIfNeeded(result)
       value = .jobExecution(success: success)
     } catch {
-      if error is DiagnosticData {
-        context.diagnosticsEngine.emit(error)
-      }
+      context.diagnosticsEngine.emit(error)
+
       // Only inform finished job if the job has been started, otherwise the build
       // system may complain about malformed output
       if (pendingFinish) {


### PR DESCRIPTION
Execution of the `MultiJobExecutor` throws a
`Driver.ErrorDiagnostics.emitted` if the job was not successful, ie. it assume any errors were already emitted. Make sure to emit an error in all paths of `ExecuteJobRule.executeJob` so that failures aren't hidden.