### PR TITLE
Allow multiple files to be indexed in a single invocation using the `-index-file` driver mode

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -107,7 +107,7 @@ extension Driver {
   /// corresponding primary set of outputs and, if not identical, the output
   /// paths to record in the index data (empty otherwise).
   mutating func addCompileInputs(primaryInputs: [TypedVirtualPath],
-                                 indexFilePath: TypedVirtualPath?,
+                                 indexFilePaths: [TypedVirtualPath],
                                  inputs: inout [TypedVirtualPath],
                                  inputOutputMap: inout [TypedVirtualPath: [TypedVirtualPath]],
                                  outputType: FileType?,
@@ -149,11 +149,11 @@ extension Driver {
       assert(!primaryInputs.isEmpty)
       usesPrimaryFileInputs = true
       primaryInputFiles = primaryInputs
-    } else if let path = indexFilePath {
+    } else if !indexFilePaths.isEmpty {
       // If -index-file is used, we perform a single compile but pass the
       // -index-file-path as a primary input file.
       usesPrimaryFileInputs = true
-      primaryInputFiles = [path]
+      primaryInputFiles = indexFilePaths
     } else {
       usesPrimaryFileInputs = false
       primaryInputFiles = []
@@ -243,17 +243,14 @@ extension Driver {
     commandLine.appendFlag("-frontend")
     addCompileModeOption(outputType: outputType, commandLine: &commandLine)
 
-    let indexFilePath: TypedVirtualPath?
-    if let indexFileArg = parsedOptions.getLastArgument(.indexFilePath)?.asSingle {
-      let path = try VirtualPath(path: indexFileArg)
-      indexFilePath = inputFiles.first { $0.file == path }
-    } else {
-      indexFilePath = nil
-    }
+    let indexFileArgs = try Set(
+      parsedOptions.arguments(for: .indexFilePath).map { try VirtualPath(path: $0.argument.asSingle) }
+    )
+    let indexFilePaths = inputFiles.filter { indexFileArgs.contains($0.file) }
 
     let (primaryOutputs, primaryIndexUnitOutputs) =
       try addCompileInputs(primaryInputs: primaryInputs,
-                           indexFilePath: indexFilePath,
+                           indexFilePaths: indexFilePaths,
                            inputs: &inputs,
                            inputOutputMap: &inputOutputMap,
                            outputType: outputType,
@@ -281,7 +278,7 @@ extension Driver {
       moduleOutputInfo: self.moduleOutputInfo,
       moduleOutputPaths: self.moduleOutputPaths,
       includeModuleTracePath: emitModuleTrace,
-      indexFilePath: indexFilePath)
+      indexFilePaths: indexFilePaths)
 
     // Forward migrator flags.
     try commandLine.appendLast(.apiDiffDataFile, from: &parsedOptions)

--- a/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
+++ b/Sources/SwiftDriver/Jobs/FrontendJobHelpers.swift
@@ -665,7 +665,7 @@ extension Driver {
                                                         moduleOutputInfo: ModuleOutputInfo,
                                                         moduleOutputPaths: SupplementalModuleTargetOutputPaths,
                                                         includeModuleTracePath: Bool,
-                                                        indexFilePath: TypedVirtualPath?) throws -> [TypedVirtualPath] {
+                                                        indexFilePaths: [TypedVirtualPath]) throws -> [TypedVirtualPath] {
     var flaggedInputOutputPairs: [(flag: String, input: TypedVirtualPath?, output: TypedVirtualPath)] = []
 
     /// Add output of a particular type, if needed.
@@ -879,7 +879,10 @@ extension Driver {
       }
       // To match the legacy driver behavior, make sure we add an entry for the
       // file under indexing and the primary output file path.
-      if let indexFilePath = indexFilePath, let idxOutput = inputOutputMap[indexFilePath]?.first {
+      for indexFilePath in indexFilePaths {
+        guard let idxOutput = inputOutputMap[indexFilePath]?.first else {
+          continue
+        }
         entries[indexFilePath.fileHandle] = [.indexData: idxOutput.fileHandle]
       }
       let outputFileMap = OutputFileMap(entries: entries)


### PR DESCRIPTION
This allows us to index multiple files in a single frontend invocation during background indexing, allowing us to share common work like module loading.

One thing that I’m not sure about is that in the previously existing single file indexing mode, we were adding `-o <module-name>.indexData` to the frontend invocation and I couldn’t figure out what that’s needed for. With the multi-file indexing mode we add that argument for every single file to index, eg. in my test case we have `-o main.indexData -o main.indexData`. As far as I can tell this does no harm but it’s worth considering during review.