### PR TITLE
Use the unversioned subdirectory in the rpath.

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -110,6 +110,11 @@ def get_swiftpm_options(args):
       swiftpm_args += [
         '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/freebsd',
       ]
+    elif '-openbsd' in args.build_target:
+      # Library rpath for swift, dispatch, Foundation, etc. when installing
+      swiftpm_args += [
+        '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/openbsd',
+      ]
     else:
       # Library rpath for swift, dispatch, Foundation, etc. when installing
       swiftpm_args += [


### PR DESCRIPTION
While we use versioned subdirectory triples for Swift module paths, this part of the rpath should be unversioned, if at the very least, for consistency.