### PR TITLE
Update `testExecutableFallbackPath` to pass on all platforms

### DIFF
--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -5693,15 +5693,10 @@ final class SwiftDriverTests: XCTestCase {
   }
 
   func testExecutableFallbackPath() throws {
-    let driver1 = try Driver(args: ["swift", "main.swift"])
-    if !driver1.targetTriple.isDarwin {
-      XCTAssertThrowsError(try driver1.toolchain.getToolPath(.dsymutil))
-    }
-
     var env = ProcessEnv.block
     env["SWIFT_DRIVER_TESTS_ENABLE_EXEC_PATH_FALLBACK"] = "1"
-    let driver2 = try Driver(args: ["swift", "main.swift"], env: env)
-    XCTAssertNoThrow(try driver2.toolchain.getToolPath(.dsymutil))
+    let driver = try Driver(args: ["swift", "main.swift"], env: env)
+    XCTAssertNoThrow(try driver.toolchain.getToolPath(.dsymutil))
   }
 
   func testVersionRequest() throws {


### PR DESCRIPTION
Amazon Linux 2023 includes a dsymutil in its LLVM package, which is installed on our builders (checking separately if that is actually required). The intent of this test seems to be mostly to make sure we are able to find all tools when allowing fallbacks, so update it to just check for that.