### PR TITLE
Specify `-swift-version` in tests that emit swiftinterfaces

### DIFF
--- a/Tests/SwiftDriverTests/CachingBuildTests.swift
+++ b/Tests/SwiftDriverTests/CachingBuildTests.swift
@@ -368,6 +368,7 @@ final class CachingBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
+                                     "-swift-version", "5",
                                      "-module-name", "ModuleOnly",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
@@ -424,6 +425,7 @@ final class CachingBuildTests: XCTestCase {
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let dependencyOracle = InterModuleDependencyOracle()
       var driver = try Driver(args: ["swiftc",
+                                     "-swift-version", "5",
                                      "-module-name", "SeparateModuleJob",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
@@ -481,6 +483,7 @@ final class CachingBuildTests: XCTestCase {
       let privateSwiftInterfacePath: AbsolutePath = path.appending(component: "testExplicitModuleVerifyInterfaceJobs.private.swiftinterface")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
+                                     "-swift-version", "5",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-I", stdlibPath.nativePathString(escaped: true),

--- a/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
+++ b/Tests/SwiftDriverTests/ExplicitModuleBuildTests.swift
@@ -906,6 +906,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
                             .appending(component: "Swift")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       let invocationArguments = ["swiftc",
+                                 "-swift-version", "5",
                                  "-incremental", "-c",
                                  "-emit-module",
                                  "-enable-library-evolution", "-emit-module-interface", "-driver-show-incremental",
@@ -963,6 +964,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
       let privateSwiftInterfacePath: AbsolutePath = path.appending(component: "testExplicitModuleVerifyInterfaceJobs.private.swiftinterface")
       let sdkArgumentsForTesting = (try? Driver.sdkArgumentsForTesting()) ?? []
       var driver = try Driver(args: ["swiftc",
+                                     "-swift-version", "5",
                                      "-I", cHeadersPath.nativePathString(escaped: true),
                                      "-I", swiftModuleInterfacesPath.nativePathString(escaped: true),
                                      "-I", stdlibPath.nativePathString(escaped: true),
@@ -2801,6 +2803,7 @@ final class ExplicitModuleBuildTests: XCTestCase {
           """
         )
         var driver = try Driver(args: ["swiftc",
+                                       "-swift-version", "5",
                                        "-experimental-emit-variant-module",
                                        "-target", "x86_64-apple-macosx10.14",
                                        "-target-variant", "x86_64-apple-ios13.1-macabi",

--- a/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverToolingInterfaceTests.swift
@@ -59,7 +59,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
                                                                         diagnosticCallback: {_,_ in }))
       }
       do { // Force no outputs
-        let testCommand = "-module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
+        let testCommand = "-swift-version 5 -module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
         var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
         XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV2(driverPath: "swiftc",
@@ -149,7 +149,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
                                                                         executor: executor))
       }
       do { // Force no outputs
-        let testCommand = "-module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
+        let testCommand = "-swift-version 5 -module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
         var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
         XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV3(driverPath: "swiftc",
@@ -336,7 +336,7 @@ final class SwiftDriverToolingInterfaceTests: XCTestCase {
                                                                         executor: executor))
       }
       do { // Force no outputs
-        let testCommand = "-module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
+        let testCommand = "-swift-version 5 -module-name foo -emit-module -emit-module-path /tmp/foo.swiftmodule -emit-objc-header -emit-objc-header-path /tmp/foo.h -enable-library-evolution -emit-module-interface -emit-module-interface-path /tmp/foo.swiftinterface -emit-library -emit-tbd -emit-tbd-path /tmp/foo.tbd -emit-dependencies -serialize-diagnostics " + inputFile.description
         var resultingFrontendArgs: [String] = []
         var emittedDiagnostics: [Diagnostic] = []
         XCTAssertFalse(getSingleFrontendInvocationFromDriverArgumentsV5(driverPath: "swiftc",


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/84244 introduces the requirement that `swift-frontend` jobs emitting a swiftinterface must explicitly specify either `-language-mode` or `-swift-version` to avoid mis-compilation of the interface. Add the necessary arguments to various tests that form their own `swift-frontend` invocations.