### PR TITLE
Add explicit `-swift-version` argument in more tests

### DIFF
--- a/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
+++ b/Tests/SwiftDriverTests/IncrementalCompilationTests.swift
@@ -78,6 +78,7 @@ final class IncrementalCompilationTests: XCTestCase {
       "-save-temps",
       "-incremental",
       "-no-color-diagnostics",
+      "-swift-version", "5",
     ]
     + inputPathsAndContents.map({ $0.0.nativePathString(escaped: false) }).sorted()
   }


### PR DESCRIPTION
https://github.com/swiftlang/swift-driver/pull/1985 missed a test suite where `-swift-version` needs to be specified explicitly.