### PR TITLE
[wasm] Pass `--table-base` to linker to reserve low function addresses

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -160,8 +160,11 @@ extension WebAssemblyToolchain {
       // The value of lowest valid address, called "global base", must be always
       // synchronized with `SWIFT_ABI_WASM32_LEAST_VALID_POINTER` defined in
       // apple/swift's runtime library.
+      let SWIFT_ABI_WASM32_LEAST_VALID_POINTER = 4096
       commandLine.appendFlag(.Xlinker)
-      commandLine.appendFlag("--global-base=4096")
+      commandLine.appendFlag("--global-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--table-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
 
       // Delegate to Clang for sanitizers. It will figure out the correct linker
       // options.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2498,6 +2498,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(commandContainsTemporaryResponsePath(cmd, "Test.autolink"))
         XCTAssertTrue(cmd.contains(.responseFilePath(.absolute(path.appending(components: "wasi", "static-executable-args.lnk")))))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--global-base=4096")]))
+        XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--table-base=4096")]))
         XCTAssertTrue(cmd.contains(.flag("-O3")))
         XCTAssertEqual(linkJob.outputs[0].file, try toPath("Test"))
 


### PR DESCRIPTION
WebAssembly does not have a reserved address space by default, so we need to explicitly reserve low addresses for extra inhabitants for enum types with pointer payloads. https://github.com/swiftlang/swift/pull/39300 added `--global-base` to reserve low data addresses, but we also need to reserve low function addresses with `--table-base` for function pointers because WebAssembly uses a separate address space for function pointers.

Corresponding legacy-driver change: https://github.com/swiftlang/swift/pull/84285