### PR TITLE
[6.2][wasm] Pass `--table-base` to linker to reserve low function addresses

### DIFF
--- a/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WebAssemblyToolchain+LinkerSupport.swift
@@ -160,8 +160,11 @@ extension WebAssemblyToolchain {
       // The value of lowest valid address, called "global base", must be always
       // synchronized with `SWIFT_ABI_WASM32_LEAST_VALID_POINTER` defined in
       // apple/swift's runtime library.
+      let SWIFT_ABI_WASM32_LEAST_VALID_POINTER = 4096
       commandLine.appendFlag(.Xlinker)
-      commandLine.appendFlag("--global-base=4096")
+      commandLine.appendFlag("--global-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
+      commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--table-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
 
       // Delegate to Clang for sanitizers. It will figure out the correct linker
       // options.

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -2541,6 +2541,7 @@ final class SwiftDriverTests: XCTestCase {
         XCTAssertTrue(commandContainsTemporaryResponsePath(cmd, "Test.autolink"))
         XCTAssertTrue(cmd.contains(.responseFilePath(.absolute(path.appending(components: "wasi", "static-executable-args.lnk")))))
         XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--global-base=4096")]))
+        XCTAssertTrue(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--table-base=4096")]))
         XCTAssertTrue(cmd.contains(.flag("-O3")))
         XCTAssertEqual(linkJob.outputs[0].file, try toPath("Test"))
 


### PR DESCRIPTION
Explanation: Fix memory corruption on WebAssembly by properly reserving low-function addresses
Original PRs: https://github.com/swiftlang/swift-driver/pull/1987
Risk: Low, this only removes a spurious error for library evolution.
Testing: Ensured at desk that the minimum problematic code won't perform bad memory access with ASan instrumentation
Reviewers: TBD