### PR TITLE
Use UUID for response file names and add 'resolveArgumentList' API which contains original command-line if a response file is used

### DIFF
--- a/Sources/SwiftDriver/Execution/ArgsResolver.swift
+++ b/Sources/SwiftDriver/Execution/ArgsResolver.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import class Foundation.NSLock
+import struct Foundation.UUID
 
 import func TSCBasic.withTemporaryDirectory
 import protocol TSCBasic.FileSystem
@@ -189,14 +190,13 @@ public final class ArgsResolver {
       (job.supportsResponseFiles && !commandLineFitsWithinSystemLimits(path: resolvedArguments[0], args: resolvedArguments)) {
       assert(!forceResponseFiles || job.supportsResponseFiles,
              "Platform does not support response files for job: \(job)")
-      // Match the integrated driver's behavior, which uses response file names of the form "arguments-[0-9a-zA-Z].resp".
-      let hash = SHA256().hash(resolvedArguments.joined(separator: " ")).hexadecimalRepresentation
-      let responseFilePath = temporaryDirectory.appending(component: "arguments-\(hash).resp")
+      let uuid = UUID().uuidString
+      let responseFilePath = temporaryDirectory.appending(component: "arguments-\(uuid).resp")
 
       // FIXME: Need a way to support this for distributed build systems...
       if let absPath = responseFilePath.absolutePath {
         let argumentBytes = ByteString(resolvedArguments[2...].map { $0.spm_shellEscaped() }.joined(separator: "\n").utf8)
-        try fileSystem.writeFileContents(absPath, bytes: argumentBytes, atomically: true)
+        try fileSystem.writeFileContents(absPath, bytes: argumentBytes)
         resolvedArguments = [resolvedArguments[0], resolvedArguments[1], "@\(absPath.pathString)"]
       }
 


### PR DESCRIPTION
Using the content hash in the response file name caused us to require using the atomic FS write API, due to a possibility that concurrently-running driver processes may encounter a need to build a common, shared module dependency with an identical command-line recipe. In such a scenario there was a possibility of a race in writing out the response file for this command. 

We have since seen challenges with the current atomic FS write APIs and this PR is an alternative approach to tackling this problem. Instead of using the content hash, we will use UUID to ensure that we do not have races when multiple drivers are creating a response file for an identical command. In addition, we add an API for build system clients so that they can directly examine the pre-response-file-creation command line arguments directly from the `ArgsResolver`, without needing to read the response file from the filesystem. 