### PR TITLE
Add -sil-output-dir and -ir-output-dir driver options

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -389,6 +389,12 @@ public struct Driver {
   /// Path to the Objective-C generated header.
   let objcGeneratedHeaderPath: VirtualPath.Handle?
 
+  /// Path to the SIL output file.
+  let silOutputPath: VirtualPath.Handle?
+
+  /// Path to the LLVM IR output file.
+  let llvmIROutputPath: VirtualPath.Handle?
+
   /// Path to the loaded module trace file.
   let loadedModuleTracePath: VirtualPath.Handle?
 
@@ -1296,6 +1302,11 @@ public struct Driver {
         emitModuleSeparately: emitModuleSeparately,
         outputFileMap: self.outputFileMap,
         moduleName: moduleOutputInfo.name)
+    // SIL and IR outputs are handled through directory options and file maps
+    // rather than single output paths, so we set these to nil to enable
+    // the supplementary output path logic in FrontendJobHelpers
+    self.silOutputPath = nil
+    self.llvmIROutputPath = nil
 
     if let loadedModuleTraceEnvVar = env["SWIFT_LOADED_MODULE_TRACE_FILE"] {
       self.loadedModuleTracePath = try VirtualPath.intern(path: loadedModuleTraceEnvVar)
@@ -3869,6 +3880,19 @@ extension Driver {
                   .intern()
     }
     return try VirtualPath.intern(path: moduleName.appendingFileTypeExtension(type))
+  }
+
+  /// Check if output file map has entries for SIL/IR to enable file map support
+  static func hasFileMapEntry(outputFileMap: OutputFileMap?, fileType: FileType) -> Bool {
+    guard let outputFileMap = outputFileMap else { return false }
+
+    // Check if any input has this file type in the output file map
+    for inputFile in outputFileMap.entries.keys {
+      if outputFileMap.entries[inputFile]?[fileType] != nil {
+        return true
+      }
+    }
+    return false
   }
 
   /// Determine if the build system has created a Project/ directory for auxiliary outputs.

--- a/Sources/SwiftDriver/Driver/OutputFileMap.swift
+++ b/Sources/SwiftDriver/Driver/OutputFileMap.swift
@@ -172,6 +172,11 @@ public struct OutputFileMap: Hashable, Codable {
     }
     return result
   }
+
+  /// Check if the output file map has any entries for the given file type
+  public func hasEntries(for fileType: FileType) -> Bool {
+    return entries.values.contains { $0[fileType] != nil }
+  }
 }
 
 /// Struct for loading the JSON file from disk.

--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -279,7 +279,8 @@ extension Driver {
       moduleOutputInfo: self.moduleOutputInfo,
       moduleOutputPaths: self.moduleOutputPaths,
       includeModuleTracePath: emitModuleTrace,
-      indexFilePaths: indexFilePaths)
+      indexFilePaths: indexFilePaths,
+      allInputs: inputs)
 
     // Forward migrator flags.
     try commandLine.appendLast(.apiDiffDataFile, from: &parsedOptions)

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -655,6 +655,7 @@ extension Option {
   public static let Isystem: Option = Option("-Isystem", .separate, attributes: [.frontend, .synthesizeInterface, .argumentIsPath], helpText: "Add directory to the system import search path")
   public static let I: Option = Option("-I", .joinedOrSeparate, attributes: [.frontend, .synthesizeInterface, .argumentIsPath], helpText: "Add directory to the import search path")
   public static let i: Option = Option("-i", .flag, group: .modes)
+  public static let irOutputDir: Option = Option("-ir-output-dir", .separate, attributes: [.frontend, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<dir>", helpText: "Output LLVM IR files to directory <dir> as additional output during compilation")
   public static let json: Option = Option("-json", .flag, attributes: [.noDriver], helpText: "Print output in JSON format.")
   public static let json_: Option = Option("--json", .flag, alias: Option.json, attributes: [.noDriver], helpText: "Print output in JSON format.")
   public static let j: Option = Option("-j", .joinedOrSeparate, attributes: [.doesNotAffectIncrementalBuild], metaVar: "<n>", helpText: "Number of commands to execute in parallel")
@@ -864,6 +865,7 @@ extension Option {
   public static let silDebugSerialization: Option = Option("-sil-debug-serialization", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Do not eliminate functions in Mandatory Inlining/SILCombine dead functions. (for debugging only)")
   public static let silInlineCallerBenefitReductionFactor: Option = Option("-sil-inline-caller-benefit-reduction-factor", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<2>", helpText: "Controls the aggressiveness of performance inlining in -Osize mode by reducing the base benefits of a caller (lower value permits more inlining!)")
   public static let silInlineThreshold: Option = Option("-sil-inline-threshold", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<50>", helpText: "Controls the aggressiveness of performance inlining")
+  public static let silOutputDir: Option = Option("-sil-output-dir", .separate, attributes: [.frontend, .argumentIsPath, .supplementaryOutput, .cacheInvariant], metaVar: "<dir>", helpText: "Output SIL files to directory <dir> as additional output during compilation")
   public static let silOwnershipVerifyAll: Option = Option("-sil-ownership-verify-all", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Verify ownership after each transform")
   public static let silStopOptznsBeforeLoweringOwnership: Option = Option("-sil-stop-optzns-before-lowering-ownership", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Stop optimizing at SIL time before we lower ownership from SIL. Intended only for SIL ossa tests")
   public static let silUnrollThreshold: Option = Option("-sil-unroll-threshold", .separate, attributes: [.helpHidden, .frontend, .noDriver], metaVar: "<250>", helpText: "Controls the aggressiveness of loop unrolling")
@@ -1610,6 +1612,7 @@ extension Option {
       Option.importPch,
       Option.importPrescan,
       Option.importUnderlyingModule,
+      Option.irOutputDir,
       Option.inPlace,
       Option.inProcessPluginServerPath,
       Option.includeSpiSymbols,
@@ -1849,6 +1852,7 @@ extension Option {
       Option.silDebugSerialization,
       Option.silInlineCallerBenefitReductionFactor,
       Option.silInlineThreshold,
+      Option.silOutputDir,
       Option.silOwnershipVerifyAll,
       Option.silStopOptznsBeforeLoweringOwnership,
       Option.silUnrollThreshold,

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -556,6 +556,220 @@ final class SwiftDriverTests: XCTestCase {
     }
   }
 
+  func testSupplementarySilAndIrOutputDirectories() throws {
+    // Test SIL output directory with multiple files (single-file compilation mode)
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-sil-output-dir", "/tmp/sil-output"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 2)
+
+      // First job should generate foo.sil in the output directory
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/foo.sil"))))
+
+      // Second job should generate bar.sil in the output directory
+      XCTAssertEqual(plannedJobs[1].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/bar.sil"))))
+    }
+
+    // Test IR output directory with multiple files (single-file compilation mode)
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-ir-output-dir", "/tmp/ir-output"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 2)
+
+      // First job should generate foo.ll in the output directory
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/ir-output/foo.ll"))))
+
+      // Second job should generate bar.ll in the output directory
+      XCTAssertEqual(plannedJobs[1].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/ir-output/bar.ll"))))
+    }
+
+    // Test both SIL and IR output directories together (single-file compilation mode)
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-sil-output-dir", "/tmp/sil-output", "-ir-output-dir", "/tmp/ir-output"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 2)
+
+      // First job should generate both foo.sil and foo.ll
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/foo.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/ir-output/foo.ll"))))
+
+      // Second job should generate both bar.sil and bar.ll
+      XCTAssertEqual(plannedJobs[1].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/bar.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/ir-output/bar.ll"))))
+    }
+
+    // Test directory options with single-file compilation
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "-emit-object", "-sil-output-dir", "/tmp/sil-output", "-o", "foo.o"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/foo.sil"))))
+    }
+
+    // Test directory options with WMO (whole module optimization)
+    do {
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-wmo", "-sil-output-dir", "/tmp/sil-output", "-ir-output-dir", "/tmp/ir-output"])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+
+      // In WMO mode, should generate output for all input files
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/foo.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/sil-output/bar.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/ir-output/foo.ll"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/ir-output/bar.ll"))))
+    }
+  }
+
+  func testSupplementarySilAndIrOutputFileMaps() throws {
+    // Test SIL and IR output file maps in WMO mode
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+        {
+          "foo.swift": {
+            "sil": "/tmp/build/foo_custom.sil",
+            "llvm-ir": "/tmp/build/foo_custom.ll"
+          },
+          "bar.swift": {
+            "sil": "/tmp/build/bar_custom.sil",
+            "llvm-ir": "/tmp/build/bar_custom.ll"
+          }
+        }
+        """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-wmo",
+                                     "-output-file-map", fileMapFile.path.pathString])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+
+      // In WMO mode with file maps, should generate SIL/IR files at specified paths
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_custom.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/build/bar_custom.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_custom.ll"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/build/bar_custom.ll"))))
+    }
+
+    // Test single-file compilation with file maps
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+        {
+          "foo.swift": {
+            "sil": "/tmp/build/foo_single.sil",
+            "llvm-ir": "/tmp/build/foo_single.ll"
+          },
+          "bar.swift": {
+            "sil": "/tmp/build/bar_single.sil",
+            "llvm-ir": "/tmp/build/bar_single.ll"
+          }
+        }
+        """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object",
+                                     "-output-file-map", fileMapFile.path.pathString])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 2)
+
+      // First job for foo.swift
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_single.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_single.ll"))))
+
+      // Second job for bar.swift
+      XCTAssertEqual(plannedJobs[1].kind, .compile)
+      try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/build/bar_single.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[1], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/build/bar_single.ll"))))
+    }
+
+    // Test partial file map (only some files have SIL/IR entries)
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+        {
+          "foo.swift": {
+            "sil": "/tmp/build/foo_partial.sil"
+          },
+          "bar.swift": {
+            "llvm-ir": "/tmp/build/bar_partial.ll"
+          }
+        }
+        """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-wmo",
+                                     "-output-file-map", fileMapFile.path.pathString])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+
+      // Should only generate files for entries that exist in the file map
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_partial.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/build/bar_partial.ll"))))
+    }
+
+    // Test that file maps work alongside directory options (file maps should take precedence)
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+        {
+          "foo.swift": {
+            "sil": "/tmp/build/foo_precedence.sil",
+            "llvm-ir": "/tmp/build/foo_precedence.ll"
+          }
+        }
+        """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-wmo",
+                                     "-sil-output-dir", "/tmp/dir-output",
+                                     "-ir-output-dir", "/tmp/dir-output",
+                                     "-output-file-map", fileMapFile.path.pathString])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+
+      // foo.swift should use file map paths (precedence over directory options)
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_precedence.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/build/foo_precedence.ll"))))
+
+      // bar.swift should fall back to directory options
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-sil-output-path"), .path(.absolute(.init(validating: "/tmp/dir-output/bar.sil"))))
+      try XCTAssertJobInvocationMatches(plannedJobs[0], .flag("-ir-output-path"), .path(.absolute(.init(validating: "/tmp/dir-output/bar.ll"))))
+    }
+
+    // Ensure file maps without SIL/IR entries don't generate spurious flags
+    try withTemporaryFile { fileMapFile in
+      let outputMapContents: ByteString = """
+        {
+          "foo.swift": {
+            "object": "/tmp/build/foo.o"
+          },
+          "bar.swift": {
+            "object": "/tmp/build/bar.o"
+          }
+        }
+        """
+      try localFileSystem.writeFileContents(fileMapFile.path, bytes: outputMapContents)
+
+      var driver = try Driver(args: ["swiftc", "foo.swift", "bar.swift", "-emit-object", "-wmo",
+                                     "-output-file-map", fileMapFile.path.pathString])
+      let plannedJobs = try driver.planBuild().removingAutolinkExtractJobs()
+      XCTAssertEqual(plannedJobs.count, 1)
+      XCTAssertEqual(plannedJobs[0].kind, .compile)
+
+      // Should not generate any SIL/IR flags when file map has no SIL/IR entries
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(Job.ArgTemplate.flag("-sil-output-path")))
+      XCTAssertFalse(plannedJobs[0].commandLine.contains(Job.ArgTemplate.flag("-ir-output-path")))
+    }
+  }
+
     func testMultithreading() throws {
       XCTAssertNil(try Driver(args: ["swiftc"]).numParallelJobs)
 


### PR DESCRIPTION
This enables generating SIL and LLVM IR files during normal compilation using the frontend -sil-output-path and -ir-output-path flags.

Supports both single-file and WMO modes with ile map integration.

rdar://160297898