### PR TITLE
Fix swift driver hanging on SIGINT by adding timeout forced exit

### DIFF
--- a/Sources/swift-driver/main.swift
+++ b/Sources/swift-driver/main.swift
@@ -67,6 +67,11 @@ do {
     // to return a corresponding exit code when done.
     processSet.terminate()
     driverInterrupted = true
+
+    // If graceful termination doesn't work within a reasonable time, force exit
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
+      exit(1)
+    }
   }
   interruptSignalSource.resume()
 


### PR DESCRIPTION
When users interrupt swift driver with ctrl+c, the llbuild engine.build() call can hang indefinitely even after child processes are terminated. Add a two second timeout to force exit if graceful termination fails.

Resolves https://github.com/swiftlang/swift-driver/issues/1798