### PR TITLE
Pass `-enable-experimental-feature Embedded` to `-print-target-info`

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -715,7 +715,8 @@ extension Driver {
                                               resourceDirPath: resourceDirPath,
                                               requiresInPlaceExecution: true,
                                               useStaticResourceDir: useStaticResourceDir,
-                                              swiftCompilerPrefixArgs: swiftCompilerPrefixArgs)
+                                              swiftCompilerPrefixArgs: swiftCompilerPrefixArgs,
+                                              isEmbedded: parsedOptions.isEmbeddedEnabled)
     }
 
     if parsedOptions.hasArgument(.printSupportedFeatures) {

--- a/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
+++ b/Sources/SwiftDriver/Jobs/PrintTargetInfoJob.swift
@@ -134,7 +134,9 @@ extension Toolchain {
                                                 runtimeCompatibilityVersion: String? = nil,
                                                 requiresInPlaceExecution: Bool = false,
                                                 useStaticResourceDir: Bool = false,
-                                                swiftCompilerPrefixArgs: [String]) throws -> Job {
+                                                swiftCompilerPrefixArgs: [String],
+                                                isEmbedded: Bool = false
+  ) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
     commandLine.append(contentsOf: [.flag("-frontend"),
                                     .flag("-print-target-info")])
@@ -167,6 +169,13 @@ extension Toolchain {
     if useStaticResourceDir {
        commandLine += [.flag("-use-static-resource-dir")]
      }
+
+    if isEmbedded {
+      commandLine += [
+        .flag("-enable-experimental-feature"),
+        .flag("Embedded")
+      ]
+    }
 
     return Job(
       moduleName: "",

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -6949,6 +6949,21 @@ final class SwiftDriverTests: XCTestCase {
       XCTAssertFalse(linkJob.commandLine.joinedUnresolvedArguments.contains("swiftrt.o"))
     }
 
+    // Printing target info needs to pass through the experimental flag.
+    do {
+      var driver = try Driver(args: [
+        "swiftc",
+        "-target",
+        "aarch64-none-none-elf",
+        "-enable-experimental-feature", "Embedded",
+        "-print-target-info"
+      ], env: env)
+
+      let jobs = try driver.planBuild()
+      let targetInfoJob = try jobs.findJob(.printTargetInfo)
+      XCTAssertTrue(targetInfoJob.commandLine.contains(.flag("Embedded")))
+    }
+
     // Embedded Wasm compile job
     do {
       var driver = try Driver(args: ["swiftc", "-target", "wasm32-none-none-wasm", "test.swift", "-enable-experimental-feature", "Embedded", "-wmo", "-o", "a.wasm"], env: env)


### PR DESCRIPTION
This is needed to get the proper runtime library paths. Fixes issue #80570 / rdar://148705734.