### PR TITLE
Pass `-no-downgrade-typecheck-interface-error` to swift-frontend

### DIFF
--- a/Sources/SwiftDriver/Jobs/Planning.swift
+++ b/Sources/SwiftDriver/Jobs/Planning.swift
@@ -545,21 +545,19 @@ extension Driver {
                                       explicitModulePlanner: ExplicitDependencyBuildPlanner?,
                                       forVariantModule: Bool = false)
   throws {
+    let verifyFlag = parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
+                                           negative: .noVerifyEmittedModuleInterface)
+
     guard
       // Only verify modules with library evolution.
       parsedOptions.hasArgument(.enableLibraryEvolution),
 
       // Only verify when requested, on by default and not disabled.
-      parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
-                            negative: .noVerifyEmittedModuleInterface,
-                            default: true),
+      verifyFlag != false,
 
       // Don't verify by default modules emitted from a merge-module job
       // as it's more likely to be invalid.
-      emitModuleSeparately || compilerMode == .singleCompile ||
-      parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
-                            negative: .noVerifyEmittedModuleInterface,
-                            default: false)
+      emitModuleSeparately || compilerMode == .singleCompile || verifyFlag == true
     else { return }
 
     // Downgrade errors to a warning for modules expected to fail this check.
@@ -569,13 +567,20 @@ extension Driver {
                               getAdopterConfigsFromXcodeDefaultToolchain()))
 
     let moduleName = parsedOptions.getLastArgument(.moduleName)?.asSingle
-    let reportAsError = !knownFailingModules.contains(moduleName ?? "") ||
-         env["ENABLE_DEFAULT_INTERFACE_VERIFIER"] != nil ||
-         parsedOptions.hasFlag(positive: .verifyEmittedModuleInterface,
-                               negative: .noVerifyEmittedModuleInterface,
-                               default: false)
+    let errorMode: InterfaceVerificationErrorMode
 
-    if !reportAsError {
+    if verifyFlag != nil {
+      assert(verifyFlag == true)
+      errorMode = .enabled
+    } else if env["ENABLE_DEFAULT_INTERFACE_VERIFIER"] != nil {
+      errorMode = .enabled
+    } else if knownFailingModules.contains(moduleName ?? "") {
+      errorMode = .downgrade
+    } else {
+      errorMode = .unspecified
+    }
+
+    if errorMode == .downgrade {
       diagnosticEngine
         .emit(
           .remark(
@@ -591,6 +596,7 @@ extension Driver {
                       forVariantModule: Bool) throws {
       var isNeeded = false
       var outputType: FileType
+      var jobErrorMode = errorMode
 
       switch mode {
       case .Public:
@@ -606,6 +612,8 @@ extension Driver {
       case .Package:
         isNeeded = parsedOptions.hasArgument(.emitPackageModuleInterfacePath)
         outputType = .packageSwiftInterface
+        // Package interfaces are experimental and should not be verified yet.
+        jobErrorMode = .downgrade
       }
 
       guard isNeeded else { return }
@@ -615,7 +623,7 @@ extension Driver {
              "Merge module job should only have one swiftinterface output")
       let job = try verifyModuleInterfaceJob(interfaceInput: mergeInterfaceOutputs[0],
                                              emitModuleJob: emitModuleJob,
-                                             reportAsError: reportAsError,
+                                             errorMode: jobErrorMode,
                                              explicitModulePlanner: explicitModulePlanner,
                                              forVariantModule: forVariantModule)
       addJob(job)

--- a/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
+++ b/Sources/SwiftDriver/Jobs/VerifyModuleInterfaceJob.swift
@@ -32,7 +32,15 @@ extension Driver {
     return isFrontendArgSupported(.inputFileKey)
   }
 
-  mutating func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath, emitModuleJob: Job, reportAsError: Bool,
+  enum InterfaceVerificationErrorMode {
+    case unspecified
+    case enabled
+    case downgrade
+  }
+
+  mutating func verifyModuleInterfaceJob(interfaceInput: TypedVirtualPath,
+                                         emitModuleJob: Job,
+                                         errorMode: InterfaceVerificationErrorMode,
                                          explicitModulePlanner: ExplicitDependencyBuildPlanner?,
                                          forVariantModule: Bool) throws -> Job {
     var commandLine: [Job.ArgTemplate] = swiftCompilerPrefixArgs.map { Job.ArgTemplate.flag($0) }
@@ -59,12 +67,15 @@ extension Driver {
       }
     }
 
-    // TODO: remove this because we'd like module interface errors to fail the build.
-    if isFrontendArgSupported(.downgradeTypecheckInterfaceError) &&
-        (!reportAsError ||
-         // package interface is new and should not be a blocker for now
-         interfaceInput.type == .packageSwiftInterface) {
+    switch errorMode {
+    case .downgrade:
       commandLine.appendFlag(.downgradeTypecheckInterfaceError)
+    case .enabled:
+      if isFrontendArgSupported(.noDowngradeTypecheckInterfaceError) {
+        commandLine.appendFlag(.noDowngradeTypecheckInterfaceError)
+      }
+    case .unspecified:
+      break
     }
 
     let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [(interfaceInput, 0)])

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -247,6 +247,7 @@ extension Option {
   public static let disableLayoutStringValueWitnesses: Option = Option("-disable-layout-string-value-witnesses", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable layout string based value witnesses")
   public static let disableLegacyTypeInfo: Option = Option("-disable-legacy-type-info", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Completely disable legacy type layout")
   public static let disableLifetimeDependenceDiagnostics: Option = Option("-disable-lifetime-dependence-diagnostics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable lifetime dependence diagnostics for Nonescapable types.")
+  public static let disableLifetimeResolution: Option = Option("-disable-lifetime-resolution", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable lifetime resolution in SIL.")
   public static let disableLlvmMergeFunctionsPass: Option = Option("-disable-llvm-merge-functions-pass", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Disable the MergeFunctionPass LLVM IR pass")
   public static let disableLlvmOptzns: Option = Option("-disable-llvm-optzns", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't run LLVM optimization passes")
   public static let disableLlvmValueNames: Option = Option("-disable-llvm-value-names", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't add names to local values in LLVM IR")
@@ -512,6 +513,7 @@ extension Option {
   public static let enableLexicalLifetimesNoArg: Option = Option("-enable-lexical-lifetimes", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable lexical lifetimes")
   public static let enableLibraryEvolution: Option = Option("-enable-library-evolution", .flag, attributes: [.frontend, .moduleInterface], helpText: "Build the module to allow binary-compatible library evolution")
   public static let enableLifetimeDependenceDiagnostics: Option = Option("-enable-lifetime-dependence-diagnostics", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable lifetime dependence diagnostics for Nonescapable types.")
+  public static let enableLifetimeResolution: Option = Option("-enable-lifetime-resolution", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Enable lifetime resolution in SIL.")
   public static let enableLlvmValueNames: Option = Option("-enable-llvm-value-names", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Add names to local values in LLVM IR")
   public static let enableLlvmVerifyEach: Option = Option("-enable-llvm-verify-each", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Run the LLVM IR verifier after every pass.")
   public static let enableLlvmVfe: Option = Option("-enable-llvm-vfe", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Use LLVM IR Virtual Function Elimination on Swift class virtual tables")
@@ -749,6 +751,7 @@ extension Option {
   public static let noClangModuleBreadcrumbs: Option = Option("-no-clang-module-breadcrumbs", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Don't emit DWARF skeleton CUs for imported Clang modules. Use this when building a redistributable static archive.")
   public static let noClangCompilerInstanceSharing: Option = Option("-no-clang-scanner-instance-sharing", .flag, attributes: [.frontend, .noDriver], helpText: "Disable sharing of the Clang compiler instance across dependency scans.")
   public static let noColorDiagnostics: Option = Option("-no-color-diagnostics", .flag, attributes: [.frontend, .doesNotAffectIncrementalBuild], helpText: "Do not print diagnostics in color")
+  public static let noDowngradeTypecheckInterfaceError: Option = Option("-no-downgrade-typecheck-interface-error", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Report errors when typechecking emitted module interfaces, even for a module blocklisted as having a broken interface")
   public static let noEmitModuleSeparatelyWMO: Option = Option("-no-emit-module-separately-wmo", .flag, attributes: [.helpHidden], helpText: "Force emitting the swiftmodule in the same job in wmo builds")
   public static let noEmitModuleSeparately: Option = Option("-no-emit-module-separately", .flag, attributes: [.helpHidden], helpText: "Force using merge-module as the incremental build mode")
   public static let driverNoExplicitModuleBuild: Option = Option("-no-explicit-module-build", .flag, attributes: [], helpText: "Opt out of the default explicit-module-build behavior for swiftc")
@@ -1058,6 +1061,7 @@ extension Option {
   public static let warnSwift3ObjcInference: Option = Option("-warn-swift3-objc-inference", .flag, alias: Option.warnSwift3ObjcInferenceComplete, attributes: [.helpHidden, .frontend, .doesNotAffectIncrementalBuild])
   public static let warningsAsErrors: Option = Option("-warnings-as-errors", .flag, attributes: [.frontend], helpText: "Treat warnings as errors", group: .warningTreating)
   public static let weakLinkAtTarget: Option = Option("-weak-link-at-target", .flag, attributes: [.helpHidden, .frontend, .noDriver], helpText: "Weakly link symbols for declarations that were introduced at the deployment target. Symbols introduced before the deployment target are still strongly linked.")
+  public static let weakLinkSpanCompatibilityLib: Option = Option("-weak-link-span-compatibility-lib", .flag, attributes: [.frontend], helpText: "Weakly link the symbols that are back deployed by the Span compatibility library instead of strongly linking them, when the deployment target predates the OS release that introduced them")
   public static let Werror: Option = Option("-Werror", .separate, attributes: [.helpHidden, .frontend], metaVar: "<diagnostic_group>", helpText: "Treat this warning group as error", group: .warningTreating)
   public static let wholeModuleOptimization: Option = Option("-whole-module-optimization", .flag, attributes: [.frontend, .noInteractive], helpText: "Optimize input files together instead of individually")
   public static let windowsSdkRoot: Option = Option("-windows-sdk-root", .separate, attributes: [.frontend, .synthesizeInterface, .argumentIsPath], metaVar: "<root>", helpText: "Windows SDK Root")
@@ -1306,6 +1310,7 @@ extension Option {
       Option.disableLayoutStringValueWitnesses,
       Option.disableLegacyTypeInfo,
       Option.disableLifetimeDependenceDiagnostics,
+      Option.disableLifetimeResolution,
       Option.disableLlvmMergeFunctionsPass,
       Option.disableLlvmOptzns,
       Option.disableLlvmValueNames,
@@ -1571,6 +1576,7 @@ extension Option {
       Option.enableLexicalLifetimesNoArg,
       Option.enableLibraryEvolution,
       Option.enableLifetimeDependenceDiagnostics,
+      Option.enableLifetimeResolution,
       Option.enableLlvmValueNames,
       Option.enableLlvmVerifyEach,
       Option.enableLlvmVfe,
@@ -1808,6 +1814,7 @@ extension Option {
       Option.noClangModuleBreadcrumbs,
       Option.noClangCompilerInstanceSharing,
       Option.noColorDiagnostics,
+      Option.noDowngradeTypecheckInterfaceError,
       Option.noEmitModuleSeparatelyWMO,
       Option.noEmitModuleSeparately,
       Option.driverNoExplicitModuleBuild,
@@ -2117,6 +2124,7 @@ extension Option {
       Option.warnSwift3ObjcInference,
       Option.warningsAsErrors,
       Option.weakLinkAtTarget,
+      Option.weakLinkSpanCompatibilityLib,
       Option.Werror,
       Option.wholeModuleOptimization,
       Option.windowsSdkRoot,

--- a/Sources/SwiftOptions/ParsedOptions.swift
+++ b/Sources/SwiftOptions/ParsedOptions.swift
@@ -304,30 +304,39 @@ extension ParsedOptions {
     return options.contains { !lookupWithoutConsuming($0).isEmpty }
   }
 
-  /// Given an option and its negative form, return
-  /// true if the option is present, false if the negation is present, and
-  /// `default` if neither option is given. If both the option and its
-  /// negation are present, the last one wins.
+  /// Given an option and its negative form, return true if the option is present,
+  /// false if the negation is present, or nil if neither option is given. If both
+  /// the option and its negation are present, the last one wins.
   public mutating func hasFlag(positive: Option,
-                               negative: Option,
-                               default: Bool) -> Bool {
+                               negative: Option) -> Bool? {
     let positiveOpt = lookup(positive).last
     let negativeOpt = lookup(negative).last
 
-    // If neither are present, return the default
     guard positiveOpt != nil || negativeOpt != nil else {
-      return `default`
+      return nil
     }
 
-    // If the positive isn't provided, then the negative will be
+    // If the positive isn't provided, negative wins
     guard let positive = positiveOpt else { return false }
 
-    // If the negative isn't provided, then the positive will be
+    // If the negative isn't provided, positive wins
     guard let negative = negativeOpt else { return true }
 
     // Otherwise, return true if the positive index is greater than the negative,
     // false otherwise
     return positive.index > negative.index
+  }
+
+  /// Given an option and its negative form, return true if the option is present,
+  /// false if the negation is present, or `default` if neither option is given.
+  /// If both the option and its negation are present, the last one wins.
+  public mutating func hasFlag(positive: Option,
+                               negative: Option,
+                               default: Bool) -> Bool {
+    guard let hasFlag = hasFlag(positive: positive, negative: negative) else {
+      return `default`
+    }
+    return hasFlag
   }
 
   /// Get the last argument matching the given option.

--- a/Tests/SwiftDriverTests/MiscDriverTests.swift
+++ b/Tests/SwiftDriverTests/MiscDriverTests.swift
@@ -1766,6 +1766,8 @@ import CRT
       expectEqual(verifyJob.inputs[0], emitInterfaceOutput[0])
       expectJobInvocationMatches(verifyJob, .path(emitInterfaceOutput[0].file))
       #expect(!verifyJob.commandLine.contains("-downgrade-typecheck-interface-error"))
+      // The blocklist applies when the verification isn't requested explicitly.
+      #expect(!verifyJob.commandLine.contains("-no-downgrade-typecheck-interface-error"))
     }
 
     // Test the `-no-verify-emitted-module-interface` flag with whole-module
@@ -1869,6 +1871,10 @@ import CRT
       #expect(plannedJobs.count == 2)
       let verifyJob = try plannedJobs.findJob(.verifyModuleInterface)
       #expect(!verifyJob.commandLine.contains("-downgrade-typecheck-interface-error"))
+      // Report errors even for modules blocklisted by the compiler.
+      if driver.isFrontendArgSupported(.noDowngradeTypecheckInterfaceError) {
+        expectJobInvocationMatches(verifyJob, .flag("-no-downgrade-typecheck-interface-error"))
+      }
     }
 
     // The flag -check-api-availability-only is not passed down to the verify job.


### PR DESCRIPTION
When `-verify-emitted-module-interface` is specified, make sure interfaces are always verified by passing `-no-downgrade-typecheck-interface-error` to swift-frontend.

Resolves rdar://185151315.