### PR TITLE
SDK: use DefaultDeploymentTarget in SDKInfo.json for -clang-target triples when the field is present

### DIFF
--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -394,6 +394,16 @@ public final class DarwinToolchain: Toolchain {
       }
       return version
     }
+
+    // Version to embed in the -clang-target[-variant] triple: the SDK's
+    // DefaultDeploymentTarget when available, else the SDK version. Mac Catalyst
+    // always uses sdkVersion(for:) so its macOS->iOS remap is preserved.
+    func clangTargetVersion(for triple: Triple) -> Version {
+      if !triple.isMacCatalyst, let defaultDeploymentTarget {
+        return defaultDeploymentTarget
+      }
+      return sdkVersion(for: triple)
+    }
   }
 
   // SDK info is computed lazily. This should not generally be accessed directly.
@@ -440,7 +450,7 @@ public final class DarwinToolchain: Toolchain {
         clangTargetTriple = explicitClangTripleArg
       } else if let sdkInfo = sdkInfo {
         let currentTriple = frontendTargetInfo.target.triple
-        let sdkVersionedOSString = currentTriple.osNameUnversioned + sdkInfo.sdkVersion(for: currentTriple).sdkVersionString
+        let sdkVersionedOSString = currentTriple.osNameUnversioned + sdkInfo.clangTargetVersion(for: currentTriple).sdkVersionString
         clangTargetTriple = currentTriple.triple.replacingOccurrences(of: currentTriple.osName, with: sdkVersionedOSString)
       }
 
@@ -461,7 +471,7 @@ public final class DarwinToolchain: Toolchain {
           let currentVariantTriple = targetVariantTripleStr
           let sdkVersionedOSSString =
             currentVariantTriple.osNameUnversioned
-            + sdkInfo.sdkVersion(for: currentVariantTriple).sdkVersionString
+            + sdkInfo.clangTargetVersion(for: currentVariantTriple).sdkVersionString
           clangTargetVariantTriple = currentVariantTriple.triple.replacingOccurrences(
             of: currentVariantTriple.osName, with: sdkVersionedOSSString)
         }

--- a/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
+++ b/Sources/SwiftDriver/Toolchains/DarwinToolchain.swift
@@ -311,6 +311,7 @@ public final class DarwinToolchain: Toolchain {
       case version = "Version"
       case versionMap = "VersionMap"
       case canonicalName = "CanonicalName"
+      case defaultDeploymentTarget = "DefaultDeploymentTarget"
     }
 
     public enum SDKPlatformKind: String, CaseIterable {
@@ -359,6 +360,7 @@ public final class DarwinToolchain: Toolchain {
     private var version: Version
     private var versionMap: VersionMap
     let canonicalName: String
+    let defaultDeploymentTarget: Version?
     init(from decoder: Decoder) throws {
       let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -377,6 +379,9 @@ public final class DarwinToolchain: Toolchain {
       } else {
         self.versionMap = VersionMap()
       }
+      self.defaultDeploymentTarget = try keyedContainer
+        .decodeIfPresent(String.self, forKey: .defaultDeploymentTarget)
+        .flatMap { try? Version(string: $0, lenient: true) }
     }
 
 

--- a/Tests/SwiftDriverTests/TargetTests.swift
+++ b/Tests/SwiftDriverTests/TargetTests.swift
@@ -1261,13 +1261,15 @@ import CRT
           """
           {
             "Version":"1.0",
-            "CanonicalName": "xros1.0"
+            "CanonicalName": "xros1.0",
+            "DefaultDeploymentTarget": "1.0"
           }
           """
       )
 
       let sdkInfo = DarwinToolchain.readSDKInfo(localFileSystem, VirtualPath.absolute(sdk).intern())
       expectEqual(sdkInfo?.platformKind, .visionos)
+      expectEqual(sdkInfo?.defaultDeploymentTarget, Version(1, 0, 0))
     }
   }
 

--- a/Tests/SwiftDriverTests/TargetTests.swift
+++ b/Tests/SwiftDriverTests/TargetTests.swift
@@ -505,6 +505,40 @@ import CRT
         }
       )
     }
+
+    // -clang-target uses the SDK's DefaultDeploymentTarget when present,
+    // while -target-sdk-version still reflects the SDK version.
+    try await withTemporaryDirectory { path in
+      let sdk = path.appending(component: "MacOSX.sdk")
+      try localFileSystem.createDirectory(sdk, recursive: true)
+      try localFileSystem.writeFileContents(
+        sdk.appending(component: "SDKSettings.json"),
+        bytes:
+          """
+          {
+            "Version": "10.15",
+            "CanonicalName": "macosx10.15",
+            "VersionMap": { "macOS_iOSMac": { "10.15": "13.3" } },
+            "DefaultDeploymentTarget": "10.13"
+          }
+          """
+      )
+      let main = path.appending(component: "Foo.swift")
+      try localFileSystem.writeFileContents(main, bytes: "import Swift")
+      var driver = try TestDriver(args: [
+        "swiftc", "-explicit-module-build",
+        "-target", "arm64-apple-macos10.14",
+        "-sdk", sdk.pathString,
+        main.pathString,
+      ])
+      let plannedJobs = try await driver.planBuild()
+      #expect(
+        plannedJobs.contains { job in
+          job.commandLine.contains(subsequence: [.flag("-clang-target"), .flag("arm64-apple-macos10.13")])
+            && job.commandLine.contains(subsequence: [.flag("-target-sdk-version"), .flag("10.15")])
+        }
+      )
+    }
   }
 
   @Test(.requireHostOS(.macosx)) func disableClangTargetForImplicitModule() async throws {


### PR DESCRIPTION
rdar://184842115