### PR TITLE
fix(windows): link static dispatch dependencies

### DIFF
--- a/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WindowsToolchain+LinkerSupport.swift
@@ -211,6 +211,23 @@ extension WindowsToolchain {
       }
     })
 
+    // Static libdispatch declares BlocksRuntime, AdvAPI32, ShLwApi, WS2_32,
+    // WinMM, and synchronization in its Windows CMake interface. OneCore and
+    // ole32 close the remaining Swift Concurrency and COM imports.
+    if parsedOptions.hasArgument(.staticStdlib) {
+      commandLine.appendFlags(
+        "-ldispatch",
+        "-lBlocksRuntime",
+        "-lAdvAPI32",
+        "-lShLwApi",
+        "-lWS2_32",
+        "-lWinMM",
+        "-lsynchronization",
+        "-lOneCore",
+        "-lole32"
+      )
+    }
+
     for framework in parsedOptions.arguments(for: .F, .Fsystem) {
       commandLine.appendFlag(framework.option == .Fsystem ? "-iframework" : "-F")
       try commandLine.appendPath(VirtualPath(path: framework.argument.asSingle))

--- a/Tests/SwiftDriverTests/LinkJobTests.swift
+++ b/Tests/SwiftDriverTests/LinkJobTests.swift
@@ -1619,6 +1619,44 @@ import Testing
     )
   }
 
+  @Test func windowsStaticStdlibLinkLibraries() async throws {
+    let commonArguments = [
+      "swiftc", "-target", "x86_64-unknown-windows-msvc", "-use-ld=lld",
+      "-emit-executable", "-nostartfiles", "input.obj",
+    ]
+    let staticLibraries = [
+      "-ldispatch",
+      "-lBlocksRuntime",
+      "-lAdvAPI32",
+      "-lShLwApi",
+      "-lWS2_32",
+      "-lWinMM",
+      "-lsynchronization",
+      "-lOneCore",
+      "-lole32",
+    ]
+
+    do {
+      var driver = try TestDriver(args: commonArguments + ["-static-stdlib"])
+      let jobs = try await driver.planBuild().removingAutolinkExtractJobs()
+      let linkJob = try jobs.findJob(.link)
+
+      for library in staticLibraries {
+        #expect(linkJob.commandLine.contains(.flag(library)))
+      }
+    }
+
+    do {
+      var driver = try TestDriver(args: commonArguments)
+      let jobs = try await driver.planBuild().removingAutolinkExtractJobs()
+      let linkJob = try jobs.findJob(.link)
+
+      for library in staticLibraries {
+        #expect(!linkJob.commandLine.contains(.flag(library)))
+      }
+    }
+  }
+
   @Test func windowsRuntimeLibraryFlags() async throws {
     do {
       var driver = try TestDriver(args: [


### PR DESCRIPTION
## Summary

Windows link jobs now carry the static Dispatch and BlocksRuntime archives plus their Windows import-library closure whenever `-static-stdlib` is active.

Dynamic standard-library links remain unchanged. Unit coverage verifies that the complete library set is present only for static-standard-library links.

## Mechanism

The pinned `swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-08-01-a` installer has SHA-256 `C287DD533A65A73D657B1B9F2305BE50552F89B46199A0F6162A287DEE547149`. It reports Swift `db4e13695491982` and LLVM `885b338ea38aee1`.

`dumpbin /symbols` on its x86_64 `libswift_Concurrency.lib` reports `dispatch_main`, `_dispatch_main_q`, and `dispatch_assert_queue` as ordinary undefined external references. No matching `__imp_` Dispatch references are present. The final static consumer must therefore supply Dispatch and BlocksRuntime.

Adding only those archives resolves the Dispatch references but exposes their transitive Windows imports. These dependencies were previously consumed while producing the DLLs. Static linking moves that responsibility to the final executable.

The pinned libdispatch source tag resolves to `2858130f9ee3a1253a286dd2b37971b93992f037`. Its Windows CMake interface declares BlocksRuntime publicly and declares `AdvAPI32`, `ShLwApi`, `WS2_32`, `WinMM`, and `synchronization` privately.

The observed interface differs slightly. `OneCore` is additionally required for the precise interrupt-time APIs referenced by Swift Concurrency. The static Dispatch objects also call `CoInitializeEx` and `CoUninitialize`, whose direct import library is `ole32`. OneCore resolves those COM imports in this SDK, but `ole32` is included explicitly. Neither OneCore nor ole32 appears in libdispatch’s CMake list. Conversely, the minimal reproducer does not pull an object requiring `synchronization`, but the driver carries it because it belongs to libdispatch’s declared interface.

## Linux parity

The GenericUnix toolchain already consumes the generated `static-stdlib-args.lnk` file for `-static-stdlib`. That file carries Dispatch, BlocksRuntime, and platform system libraries such as `dl`, `pthread`, `stdc++`, and `m`.

Windows has no equivalent static link response file. This change supplies the corresponding archive and system-library closure directly in the Windows link job.

## Testing

The focused Windows link-job test failed before the transitive libraries were added and now passes. It verifies that all nine libraries are present with `-static-stdlib` and absent without it.

`swift test --parallel` passes all 470 tests across 40 suites. The unacceptable-language, license-header, and broken-symlink checks pass. The changed Swift ranges were formatted with swift-format 6.3.0, and `git diff --check` passes.

The stock driver fails the exact reproducer with these undefined symbols:

```text
_dispatch_main_q
__declspec(dllimport) QueryInterruptTimePrecise
__declspec(dllimport) QueryUnbiasedInterruptTimePrecise
dispatch_main
dispatch_assert_queue
_dispatch_queue_attr_concurrent
dispatch_queue_attr_make_with_qos_class
dispatch_queue_create
dispatch_queue_set_width
dispatch_release
dispatch_walltime
dispatch_after_f
_dispatch_source_type_timer
dispatch_source_create
dispatch_source_set_timer
dispatch_set_context
dispatch_source_set_event_handler_f
dispatch_activate
dispatch_async_f
```

An archives-only validation resolves those Dispatch symbols and exposes these 16 transitive Windows symbols:

```text
QueryInterruptTimePrecise
QueryUnbiasedInterruptTimePrecise
CoInitializeEx
CoUninitialize
PathIsRelativeA
recv
send
WSAGetLastError
ioctlsocket
timeBeginPeriod
timeEndPeriod
timeGetDevCaps
WSAEventSelect
WSAEnumNetworkEvents
GetThreadWaitChain
OpenThreadWaitChainSession
```

The final patched driver builds the unchanged reproducer with:

```text
swift build -c release -Xswiftc -static-stdlib
```

The command links and the executable exits successfully without `import Dispatch` or additional flags. The verbose linker invocation contains:

```text
dispatch.lib BlocksRuntime.lib AdvAPI32.lib ShLwApi.lib WS2_32.lib WinMM.lib synchronization.lib OneCore.lib ole32.lib
```

The negative control builds and runs successfully without `-static-stdlib`. Neither `dispatch.lib` nor `BlocksRuntime.lib` appears in that link.

The complete toolchain version is:

```text
Swift version 6.4-dev (LLVM 885b338ea38aee1, Swift db4e13695491982)
Target: x86_64-unknown-windows-msvc
Build config: +assertions
```

Fixes swiftlang/swift#91648
