### PR TITLE
Forward `-index-store-compress` from the driver to the frontend invocations

### DIFF
--- a/Sources/SwiftDriver/Jobs/CompileJob.swift
+++ b/Sources/SwiftDriver/Jobs/CompileJob.swift
@@ -412,6 +412,7 @@ extension Driver {
       }
       try commandLine.appendLast(.indexIgnoreClangModules, from: &parsedOptions)
       try commandLine.appendLast(.indexIncludeLocals, from: &parsedOptions)
+      try commandLine.appendLast(.indexStoreCompress, from: &parsedOptions)
     }
 
     if parsedOptions.contains(.debugInfoStoreInvocation) ||

--- a/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCHJob.swift
@@ -24,6 +24,7 @@ extension Driver {
       explicitModulePlanner: explicitModulePlanner)
 
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+    try commandLine.appendLast(.indexStoreCompress, from: &parsedOptions)
 
     commandLine.appendFlag(.emitPch)
   }

--- a/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
+++ b/Sources/SwiftDriver/Jobs/GeneratePCMJob.swift
@@ -55,6 +55,7 @@ extension Driver {
       explicitModulePlanner: explicitModulePlanner)
 
     try commandLine.appendLast(.indexStorePath, from: &parsedOptions)
+    try commandLine.appendLast(.indexStoreCompress, from: &parsedOptions)
     let cacheKeys = try computeOutputCacheKeyForJob(commandLine: commandLine, inputs: [(input, 0)])
 
     return Job(

--- a/Tests/SwiftDriverTests/DriverOptionTests.swift
+++ b/Tests/SwiftDriverTests/DriverOptionTests.swift
@@ -380,6 +380,58 @@ import Testing
     }
   }
 
+  @Test func indexStoreCompress() async throws {
+    // Make sure `-index-store-compress` is only passed to the frontend when
+    // requested, not by default.
+    try await assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-index-store-path", "/tmp/idx") { driver in
+      let jobs = try await driver.planBuild()
+      #expect(!jobs[0].commandLine.contains(.flag("-index-store-compress")))
+    }
+    try await assertNoDriverDiagnostics(
+      args: "swiftc",
+      "foo.swift",
+      "-index-store-path",
+      "/tmp/idx",
+      "-index-store-compress"
+    ) { driver in
+      let jobs = try await driver.planBuild()
+      expectCommandLineContains(jobs[0].commandLine, .flag("-index-store-path"))
+      expectCommandLineContains(jobs[0].commandLine, .flag("-index-store-compress"))
+    }
+    // Ensure the index store for precompiled headers and modules also get compressed.
+    try await assertNoDriverDiagnostics(
+      args: "swiftc",
+      "-typecheck",
+      "-index-store-path",
+      "/tmp/idx",
+      "-index-store-compress",
+      "-import-objc-header",
+      "TestInputHeader.h",
+      "foo.swift"
+    ) { driver in
+      let jobs = try await driver.planBuild()
+      #expect(jobs[0].kind == .generatePCH)
+      print(jobs[0].commandLine)
+      expectCommandLineContains(jobs[0].commandLine, .flag("-index-store-path"))
+      expectCommandLineContains(jobs[0].commandLine, .flag("-index-store-compress"))
+    }
+    try await assertNoDriverDiagnostics(
+      args: "swiftc",
+      "-emit-pcm",
+      "module.modulemap",
+      "-module-name",
+      "Test",
+      "-index-store-path",
+      "/tmp/idx",
+      "-index-store-compress"
+    ) { driver in
+      let jobs = try await driver.planBuild()
+      #expect(jobs[0].kind == .generatePCM)
+      expectCommandLineContains(jobs[0].commandLine, .flag("-index-store-path"))
+      expectCommandLineContains(jobs[0].commandLine, .flag("-index-store-compress"))
+    }
+  }
+
   @Test func debugSettings() async throws {
     try await assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module") { driver in
       #expect(driver.debugInfo.level == nil)


### PR DESCRIPTION
We accepted `-index-store-compress` as a driver flag but didn’t end up forwarding it to the frontend. Instead, we silently dropped it.