### PR TITLE
[wasm] Pass --no-stack-first to wasm-ld

### DIFF
--- a/Sources/SwiftDriver/Jobs/WASIToolchain+LinkerSupport.swift
+++ b/Sources/SwiftDriver/Jobs/WASIToolchain+LinkerSupport.swift
@@ -147,6 +147,8 @@ extension WASIToolchain {
       // apple/swift's runtime library.
       let SWIFT_ABI_WASM32_LEAST_VALID_POINTER = 4096
       commandLine.appendFlag(.Xlinker)
+      commandLine.appendFlag("--no-stack-first")
+      commandLine.appendFlag(.Xlinker)
       commandLine.appendFlag("--global-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")
       commandLine.appendFlag(.Xlinker)
       commandLine.appendFlag("--table-base=\(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)")

--- a/Tests/SwiftDriverTests/LinkJobTests.swift
+++ b/Tests/SwiftDriverTests/LinkJobTests.swift
@@ -749,6 +749,7 @@ import Testing
         #expect(
           cmd.contains(.responseFilePath(.absolute(path.appending(components: "wasi", "static-executable-args.lnk"))))
         )
+        #expect(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--no-stack-first")]))
         #expect(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--global-base=4096")]))
         #expect(cmd.contains(subsequence: [.flag("-Xlinker"), .flag("--table-base=4096")]))
         #expect(


### PR DESCRIPTION
wasm-ld defaults to --stack-first since llvm/llvm-project#166998. That layout places the stack at address 0, and makes wasm-ld reject any --global-base below the stack size. Since the WASI toolchain passes --global-base=4096 and -z stack-size=131072, every WASI link now fails with:

  wasm-ld: error: --global-base cannot be less than stack size when
  --stack-first is used

Placing the stack at zero would also violate the assumption that addresses below SWIFT_ABI_WASM32_LEAST_VALID_POINTER are unused, which the pointer representation relies on for extra inhabitants. Opt out explicitly, matching what the Emscripten toolchain already does through -sGLOBAL_BASE.