### PR TITLE
[Explicit Module Builds] Avoid repeatedly collecting header module dependencies

### DIFF
--- a/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
+++ b/Sources/SwiftDriver/ExplicitModuleBuilds/ExplicitDependencyBuildPlanner.swift
@@ -467,13 +467,16 @@ public typealias ExternalTargetModuleDetailsMap = [ModuleDependencyId: ExternalT
     guard let moduleDependencies = reachabilityMap[moduleId] else {
       fatalError("Expected reachability information for the module: \(moduleId.moduleName).")
     }
+    let bridgingHeaderDeps = try Self.collectHeaderModuleDeps(
+      of: moduleId,
+      in: dependencyGraph,
+      reachabilityMap: reachabilityMap
+    )
     for dependencyId in moduleDependencies {
       try Self.addModuleDependency(of: moduleId, in: dependencyGraph, dependencyId: dependencyId,
                                    clangDependencyArtifacts: &clangDependencyArtifacts,
                                    swiftDependencyArtifacts: &swiftDependencyArtifacts,
-                                   bridgingHeaderDeps: try collectHeaderModuleDeps(of: moduleId,
-                                                                                   in: dependencyGraph,
-                                                                                   reachabilityMap: reachabilityMap))
+                                   bridgingHeaderDeps: bridgingHeaderDeps)
     }
   }
 


### PR DESCRIPTION
Change `collectHeaderModuleDeps` to be called only once outside the loop.

## Details

In the main branch, `collectHeaderModuleDeps` is called for each dependency in the loop, even though its inputs remain unchanged throughout the iteration. Because the function traverses the same set of reachable module dependencies on every call, the same work is repeated unnecessarily.

This PR moves the call outside the loop, so the calculation is performed only once.
