### PR TITLE
Remove red color from the welcome message (#2182)

### DIFF
--- a/Sources/swift-help/main.swift
+++ b/Sources/swift-help/main.swift
@@ -97,13 +97,12 @@ struct SwiftHelp: ParsableCommand {
   func printIntro() {
     let is256Color = ProcessEnv.block["TERM"] == "xterm-256color" ||
       ProcessEnv.block["TERM"] == "screen-256color"
-    let orangeRed = is256Color ? "\u{001b}[1;38;5;196m" : ""
     let plain = is256Color ? "\u{001b}[0m" : ""
     let plainBold = is256Color ? "\u{001b}[1m" : ""
 
     print("""
 
-    \(orangeRed)Welcome to Swift!\(plain)
+    \(plainBold)Welcome to Swift!\(plain)
 
     \(plainBold)Subcommands:\(plain)
 


### PR DESCRIPTION
Replace red color on the welcome message with bold white, to not appear as an alert/error message.