### PR TITLE
[CI][Test] Fix missing `IssueHandlingTrait` build error in Swift 6.1

### DIFF
--- a/Tests/SwiftDriverTests/AssertDiagnosticsTests.swift
+++ b/Tests/SwiftDriverTests/AssertDiagnosticsTests.swift
@@ -20,7 +20,11 @@ import Testing
 // fail when they're supposed to, we use `withKnownIssue` to catch expected
 // failures.
 
-@Suite(.suppressKnownIssues())
+#if compiler(>=6.3)
+@Suite(.filterIssues { $0.isFailure })
+#else
+@Suite()
+#endif
 struct AssertDiagnosticsTests {
   @Test func noDiagnostics() async throws {
     await assertNoDiagnostics { _ in }
@@ -178,17 +182,5 @@ private func expectedIssue(
       issueConfirmation.confirm()
       return true
     }
-  }
-}
-
-private extension Trait where Self == IssueHandlingTrait {
-  /// Filter out known issues, keeping only real failures (like confirmation miscounts).
-  static func suppressKnownIssues() -> Self {
-    #if compiler(>=6.3)
-    .filterIssues { $0.isFailure }
-    #else
-    // Older version do not have the API to filter so test will show as known issue.
-    .filterIssues { issue in true }
-    #endif
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes a build error that prevents the tests from running with Swift 6.1: “cannot find `IssueHandlingTrait`”.

[This project’s pull request tests](https://github.com/swiftlang/swift-driver/blob/e1d6a2fefe27dd2d7cfae18154a250c846743deb/.github/workflows/pull_request.yml#L17) use [a reusable workflow from the main branch of swiftlang/github-workflows](https://github.com/swiftlang/github-workflows/blob/main/.github/workflows/swift_package_test.yml). After [PR #309](https://github.com/swiftlang/github-workflows/pull/309) was merged into that repository’s main branch, Swift 6.1 became part of this project’s CI test matrix.

The build error has likely prevented the Swift 6.1 tests from running since that change. For example, see [the CI run for PR #2180](https://github.com/swiftlang/swift-driver/actions/runs/33844060563/job/100932062747?pr=2180).

## Changes

- Remove the extension on `IssueHandlingTrait`.
- Apply `@Suite(.filterIssues { $0.isFailure })` only in Swift 6.3 and later.

On the current main branch, issue handling through `IssueHandlingTrait` is only active in Swift 6.3 and later. The extension performs no issue handling in Swift 6.2, so removing it preserves that behavior while allowing the tests to build with Swift 6.1.