### PR TITLE
Add flag to avoid emitting `.swiftdoc` files

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -4073,6 +4073,7 @@ extension Driver {
     outputFileMap: OutputFileMap?,
     moduleName: String
   ) throws -> VirtualPath.Handle? {
+    guard !parsedOptions.hasArgument(.avoidEmitModuleDoc) else { return nil }
     return try computeModuleAuxiliaryOutputPath(&parsedOptions,
                                                 moduleOutputPath: moduleOutputPath,
                                                 type: .swiftDocumentation,

--- a/Sources/SwiftOptions/Options.swift
+++ b/Sources/SwiftOptions/Options.swift
@@ -46,6 +46,7 @@ extension Option {
   public static let autoBridgingHeaderChaining: Option = Option("-auto-bridging-header-chaining", .flag, attributes: [.helpHidden, .frontend], helpText: "Automatically chaining all the bridging headers")
   public static let autolinkForceLoad: Option = Option("-autolink-force-load", .flag, attributes: [.helpHidden, .frontend, .moduleInterface], helpText: "Force ld to link against this module even if no symbols are used")
   public static let autolinkLibrary: Option = Option("-autolink-library", .separate, attributes: [.frontend, .noDriver], helpText: "Add dependent library")
+  public static let avoidEmitModuleDoc: Option = Option("-avoid-emit-module-doc", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "don't emit Swift module documentation file")
   public static let avoidEmitModuleSourceInfo: Option = Option("-avoid-emit-module-source-info", .flag, attributes: [.noInteractive, .doesNotAffectIncrementalBuild], helpText: "don't emit Swift source info file")
   public static let avoidLocation: Option = Option("-avoid-location", .flag, attributes: [.noDriver], helpText: "Avoid serializing the file paths of SDK nodes.")
   public static let avoidLocation_: Option = Option("--avoid-location", .flag, alias: Option.avoidLocation, attributes: [.noDriver], helpText: "Avoid serializing the file paths of SDK nodes.")
@@ -1108,6 +1109,7 @@ extension Option {
       Option.autoBridgingHeaderChaining,
       Option.autolinkForceLoad,
       Option.autolinkLibrary,
+      Option.avoidEmitModuleDoc,
       Option.avoidEmitModuleSourceInfo,
       Option.avoidLocation,
       Option.avoidLocation_,

--- a/Tests/SwiftDriverTests/OutputJobTests.swift
+++ b/Tests/SwiftDriverTests/OutputJobTests.swift
@@ -1034,6 +1034,22 @@ import Testing
     }
   }
 
+  @Test func moduleDocFileEmitOption() async throws {
+    // avoid implicit swiftdoc
+    do {
+      var driver = try TestDriver(args: ["swiftc", "-emit-module", "-avoid-emit-module-doc", "foo.swift"])
+      let plannedJobs = try await driver.planBuild()
+      let emitModuleJob = plannedJobs[0]
+      #expect(!emitModuleJob.commandLine.contains(.flag("-emit-module-doc-path")))
+      expectEqual(emitModuleJob.outputs.count, driver.targetTriple.isDarwin ? 3 : 2)
+      #expect(try emitModuleJob.outputs[0].file == toPath("foo.swiftmodule"))
+      #expect(try emitModuleJob.outputs[1].file == toPath("foo.swiftsourceinfo"))
+      if driver.targetTriple.isDarwin {
+        #expect(try emitModuleJob.outputs[2].file == toPath("foo.abi.json"))
+      }
+    }
+  }
+
   @Test func filelist() async throws {
     var envVars = ProcessEnv.block
     envVars["SWIFT_DRIVER_LD_EXEC"] = try ld.nativePathString(escaped: false)


### PR DESCRIPTION
Adding `-avoid-emit-module-doc`, just like `-avoid-emit-module-source-info`, and tests that implicit .swiftdoc emission is disabled when flag is passed.

This allows build systems to skip unused .swiftdoc artifacts, to reduce unnecessary output, storage, and cache overhead when module documentation is not needed.

Companion to https://github.com/swiftlang/swift/pull/92005