### PR TITLE
makeOptions: take the SubCommandIDsOffset field emitted by LLVM's options tables

### DIFF
--- a/Sources/makeOptions/makeOptions.cpp
+++ b/Sources/makeOptions/makeOptions.cpp
@@ -108,7 +108,7 @@ using namespace llvm::opt;
 static const RawOption rawOptions[] = {
 #define OPTION(PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID, KIND, GROUP, ALIAS,  \
                ALIASARGS, FLAGS, VISIBILITY, PARAM, HELPTEXT,                  \
-               HELPTEXTFORVARIANTS, METAVAR, VALUES)                           \
+               HELPTEXTFORVARIANTS, METAVAR, VALUES, ...)                      \
   {OPT_##ID,                                                                   \
    getPrefixes(PREFIXES_OFFSET),                                               \
    getPrefixedName(PREFIXED_NAME_OFFSET),                                      \


### PR DESCRIPTION
`makeOptions` reads the Swift compiler's `Options.inc` by defining an `OPTION` macro that the file expands once per option. LLVM 23 added a trailing field to those entries (`SubCommandIDsOffset`), so each expansion now passes one more argument than our macro accepts:

```
Options.inc(1111,261): error: too many arguments provided to function-like macro invocation
makeOptions.cpp(109,9): note: macro 'OPTION' defined here
```

Ended the parameter list with `...` instead of naming the new field. `main` has to build against LLVM 21 and 22, which still emit 14 fields, so pinning the count either way breaks one of them; ignoring the tail works for both and for whatever gets appended next.

Only the Windows toolchain build compiles this: `makeOptions` sits behind `SWIFT_DRIVER_BUILD_TOOLS`, which defaults to `NO` and is only set by `build.ps1`. It broke `Build-SwiftDriver` there.